### PR TITLE
Corrected the nc command to work with latest ncat version

### DIFF
--- a/components/cookbooks/azure_lb/recipes/add.rb
+++ b/components/cookbooks/azure_lb/recipes/add.rb
@@ -186,7 +186,8 @@ def create_frontend_ipconfig(subscription_id, rg_name, lb_name, frontend_name, p
 
   if public_ip.nil?
     frontend_ipconfig_props.subnet = subnet
-    frontend_ipconfig_props.private_ipallocation_method = IpAllocationMethod::Static
+    #frontend_ipconfig_props.private_ipallocation_method = IpAllocationMethod::Static
+    frontend_ipconfig_props.private_ipallocation_method = IpAllocationMethod::Dynamic
   else
     frontend_ipconfig_props.public_ipaddress = public_ip
   end
@@ -267,7 +268,7 @@ def create_lb_rule(lb_rule_name, load_distribution, protocol, frontend_port, bac
   # With a single definition of a load balancer resource, you can define multiple load balancing rules,
   # each rule reflecting a combination of a frontend IP and port and backend IP and port associated with VMs.
   lb_rule_props = LoadBalancingRulePropertiesFormat.new
-  # lb_rule_props.probe = probe
+  lb_rule_props.probe = probe
   lb_rule_props.protocol = protocol
   lb_rule_props.backend_port = backend_port
   lb_rule_props.frontend_port = frontend_port
@@ -569,7 +570,12 @@ listeners.each do |listener|
   backend_port = listener.iport
   protocol = Azure::ARM::Network::Models::TransportProtocol::Tcp
   load_distribution = Azure::ARM::Network::Models::LoadDistribution::Default
-  lb_rule = create_lb_rule(lb_rule_name, load_distribution, protocol, frontend_port, backend_port, nil, frontend_ip_config, backend_address_pool)
+  probe = nil
+  if probes.length > 0
+    probe = probes[0]
+  end
+
+  lb_rule = create_lb_rule(lb_rule_name, load_distribution, protocol, frontend_port, backend_port, probe, frontend_ip_config, backend_address_pool)  
   lb_rules.push(lb_rule)
 end
 

--- a/components/cookbooks/azure_lb/recipes/add.rb
+++ b/components/cookbooks/azure_lb/recipes/add.rb
@@ -186,7 +186,6 @@ def create_frontend_ipconfig(subscription_id, rg_name, lb_name, frontend_name, p
 
   if public_ip.nil?
     frontend_ipconfig_props.subnet = subnet
-    #frontend_ipconfig_props.private_ipallocation_method = IpAllocationMethod::Static
     frontend_ipconfig_props.private_ipallocation_method = IpAllocationMethod::Dynamic
   else
     frontend_ipconfig_props.public_ipaddress = public_ip

--- a/components/cookbooks/fqdn/recipes/build_entries_list.rb
+++ b/components/cookbooks/fqdn/recipes/build_entries_list.rb
@@ -190,7 +190,7 @@ end
 ns_list = `dig +short NS #{domain_name}`.split("\n")
 ns = nil
 ns_list.each do |n|
-  `nc -w 2 #{n} 53`
+  `echo "EOF"|nc -w 2 #{n} 53`
   if $?.to_i == 0
     ns = n
     break

--- a/components/cookbooks/fqdn/recipes/get_designate_connection.rb
+++ b/components/cookbooks/fqdn/recipes/get_designate_connection.rb
@@ -24,6 +24,8 @@ cloud_name = node[:workorder][:cloud][:ciName]
 service = node[:workorder][:services][:dns][cloud_name][:ciAttributes]
 domain_name = service[:zone] 
 domain_name += "."
+os_type = node[:workorder][:services][:compute][cloud_name][:ciAttributes][:ostype]
+node.set["os_type"]=os_type
 
 user = {"username" => service[:username],
         "password" => service[:password]}
@@ -78,7 +80,7 @@ node.set["designate_zone"] = zone
 ns_list = `dig +short NS #{domain_name}`.split("\n")
 ns = nil
 ns_list.each do |n|
-  `nc -w 2 #{n} 53`
+  `echo "EOF"|nc -w 2 #{n} 53`
   if $?.to_i == 0
   ns = n
   break

--- a/components/cookbooks/fqdn/recipes/get_fog_connection.rb
+++ b/components/cookbooks/fqdn/recipes/get_fog_connection.rb
@@ -71,8 +71,8 @@ domain = domain_parts.join(".")
 ns_list = `dig +short NS #{domain}`.split("\n")
 ns = nil
 ns_list.each do |n|
-  `nc -w 2 #{n} 53`
-  if $?.to_i == 0
+`echo "EOF"|nc -w 2 #{n} 53`
+if $?.to_i == 0
   ns = n
   break
   else

--- a/components/cookbooks/fqdn/recipes/get_infoblox_connection.rb
+++ b/components/cookbooks/fqdn/recipes/get_infoblox_connection.rb
@@ -50,7 +50,7 @@ node.set["infoblox_conn"] = conn
 ns_list = `dig +short NS #{domain_name}`.split("\n")
 ns = nil
 ns_list.each do |n|
-  `nc -w 2 #{n} 53`
+`echo "EOF"|nc -w 2 #{n} 53`  
   if $?.to_i == 0
     ns = n
     break

--- a/components/cookbooks/fqdn/recipes/remove_old_aliases_infoblox.rb
+++ b/components/cookbooks/fqdn/recipes/remove_old_aliases_infoblox.rb
@@ -88,8 +88,8 @@ domain_name = node[:workorder][:services][:dns][cloud_name][:ciAttributes][:zone
 ns_list = `dig +short NS #{domain_name}`.split("\n")
 ns = nil
 ns_list.each do |n|
-  `nc -w 2 #{n} 53`
-  if $?.to_i == 0
+ `echo "EOF"|nc -w 2 #{n} 53`
+ if $?.to_i == 0
   ns = n
   break
   else


### PR DESCRIPTION
Corrected the nc command to work with latest ncat version in fqdn recipes.
'-w' switch is not working the same way with the latest ncat comand. So fixed it with right way of using the ncat command. and also added probe to azure load balancing rules.