### PR TITLE
putting the require back

### DIFF
--- a/components/cookbooks/azuredns/recipes/remove_old_aliases.rb
+++ b/components/cookbooks/azuredns/recipes/remove_old_aliases.rb
@@ -1,3 +1,4 @@
+require File.expand_path('../../libraries/record_set.rb', __FILE__)
 
 cloud_name = node['workorder']['cloud']['ciName']
 domain_name = node['workorder']['services']['dns'][cloud_name]['ciAttributes']['zone']


### PR DESCRIPTION
Somehow the require was removed and it is needed to use the AzureDns::RecordSet class.