### PR TITLE
adding a util method to set the proxy if it exists as a cloud var

### DIFF
--- a/components/cookbooks/azure/libraries/azure_utils.rb
+++ b/components/cookbooks/azure/libraries/azure_utils.rb
@@ -2,6 +2,8 @@
 
 module AzureCommon
   class AzureUtils
+
+    # method to get credentials in order to call Azure
     def self.get_credentials(tenant_id, client_id, client_secret)
       begin
         # Create authentication objects
@@ -18,5 +20,16 @@ module AzureCommon
         raise e
       end
     end
+
+    # if there is an apiproxy cloud var define, set it on the env.
+    def set_proxy(cloud_vars)
+      cloud_var.each do |var|
+        if var[:ciName] == 'apiproxy'
+          ENV['http_proxy'] = var[:ciAttributes][:value]
+          ENV['https_proxy'] = var[:ciAttributes][:value]
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This is just the util method to set the proxy if the cloud var exists for Azure.

Changes to use the util method will follow in other PRs.