### PR TITLE
errors with couchbase cluster when redundant is used

### DIFF
--- a/components/cookbooks/cb_cluster/recipes/base.rb
+++ b/components/cookbooks/cb_cluster/recipes/base.rb
@@ -20,25 +20,18 @@ if @availability_mode == 'single'
   pass = cba['adminpassword']
   port = cba['port']
 else
-
-  # dynamic payload defined in the pack to get the resources
-  dependencies = node.workorder.payLoad.cm
-  dependencies.each do |depends_on|
-    class_name = depends_on["ciClassName"].downcase.gsub("bom\.","")
-    Chef::Log.info("class_name:#{class_name}")
-    if class_name == "couchbase"
-      if depends_on["ciAttributes"].has_key?("adminuser")
-        user = depends_on["ciAttributes"]["adminuser"]
-      end
-
-      if depends_on["ciAttributes"].has_key?("adminpassword")
-        pass = depends_on["ciAttributes"]["adminpassword"]
-      end
-
-      if depends_on["ciAttributes"].has_key?("port")
-        port = depends_on["ciAttributes"]["port"]
-      end
-    end
+  realizedAttrs = node.workorder.payLoad[:RealizedAs][0].ciAttributes
+  if realizedAttrs.has_key?("adminuser")
+    user = realizedAttrs["adminuser"]
+  end
+  if realizedAttrs.has_key?("adminuser")
+    user = realizedAttrs["adminuser"]
+  end
+  if realizedAttrs.has_key?("adminpassword")
+    pass = realizedAttrs["adminpassword"]
+  end
+  if realizedAttrs.has_key?("port")
+    port = realizedAttrs["port"]
   end
 end
 

--- a/components/cookbooks/couchbase/libraries/component/bucket_component.rb
+++ b/components/cookbooks/couchbase/libraries/component/bucket_component.rb
@@ -47,26 +47,22 @@ module Couchbase
                     port = cba['port']
                     cluster_credentials = ClusterCredentials.new(user, pass, port)
                 else
-                    # dynamic payload defined in the pack to get the resources
-                    dependencies = @data.workorder.payLoad.cb
-                    dependencies.each do |depends_on|
-                        class_name = depends_on["ciClassName"].downcase.gsub("bom\.","")
-                        Chef::Log.info("class_name:#{class_name}")
-                        if class_name == "couchbase"
-                            if depends_on["ciAttributes"].has_key?("adminuser")
-                                user = depends_on["ciAttributes"]["adminuser"]
-                            end
-
-                            if depends_on["ciAttributes"].has_key?("adminpassword")
-                                pass = depends_on["ciAttributes"]["adminpassword"]
-                            end
-
-                            if depends_on["ciAttributes"].has_key?("port")
-                                port = depends_on["ciAttributes"]["port"]
-                            end
-                        end
-                        cluster_credentials = ClusterCredentials.new(user, pass, port)
+                  # dynamic payload defined in the pack to get the resources -
+                  # this seems to be in the RealizedAttrs...
+                    realizedAttrs = @data.workorder.payLoad[:RealizedAs][0].ciAttributes
+                    if realizedAttrs.has_key?("adminuser")
+                      user = realizedAttrs["adminuser"]
                     end
+                    if realizedAttrs.has_key?("adminuser")
+                      user = realizedAttrs["adminuser"]
+                    end
+                    if realizedAttrs.has_key?("adminpassword")
+                      pass = realizedAttrs["adminpassword"]
+                    end
+                    if realizedAttrs.has_key?("port")
+                      port = realizedAttrs["port"]
+                    end
+                    cluster_credentials = ClusterCredentials.new(user, pass, port)
                 end
               cluster_credentials
             end


### PR DESCRIPTION
data.workorder.payLoad.cb not available in couchbase/library/compenents/bucket_component.rb, use realizedAttrs instead to get admin credentials

node.workorder.payLoad.cm not available in cb_cluster/recipes/base.rb, use realizedAttrs for admin credentials