### PR TITLE
convert dns_record to lowercase so it doesn't fail on dns check

### DIFF
--- a/components/cookbooks/fqdn/recipes/build_entries_list.rb
+++ b/components/cookbooks/fqdn/recipes/build_entries_list.rb
@@ -56,6 +56,8 @@ def get_dns_values (components)
         dns_record = attrs[:shared_ip]
       end
     else
+      # dns_record must be all lowercase
+      dns_record.downcase!
       # unless ends w/ . or is an ip address
       dns_record += '.' unless dns_record =~ /,|\.$|^\d+\.\d+\.\d+\.\d+$/
     end


### PR DESCRIPTION
while testing on AWS dns creation would failed whenever dns_record has uppercase.  This would normalize dns_record to all lowercase.