### PR TITLE
update azure-base metadata due to knife sync failure

### DIFF
--- a/components/cookbooks/azure_base/metadata.rb
+++ b/components/cookbooks/azure_base/metadata.rb
@@ -1,7 +1,12 @@
-name             'azure_base'
+name             'Azure_base'
 maintainer       'OneOps'
 maintainer_email 'support@oneops.com'
 license          'Apache License, Version 2.0'
 description      'Provides basic Azure facilities for OneOps.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
+
+grouping 'default',
+         :access => "global",
+         :packages => [ 'base', 'mgmt.cloud.service', 'cloud.service' ],
+         :namespace => true


### PR DESCRIPTION
Updated azure-base metadata because it was failing on knife sync do to grouping missing.