### PR TITLE
Azure Network Security Group

### DIFF
--- a/components/cookbooks/azure/libraries/network_security_group.rb
+++ b/components/cookbooks/azure/libraries/network_security_group.rb
@@ -1,0 +1,198 @@
+require 'azure_mgmt_network'
+
+module AzureNetwork
+
+  class NetworkSecurityGroup
+    include Azure::ARM::Network
+    include Azure::ARM::Network::Models
+    
+    def initialize(credentials, subscription_id)
+      @client = Azure::ARM::Network::NetworkResourceProviderClient.new(credentials)
+      @client.subscription_id = subscription_id
+    end
+    
+    def get(resource_group_name, network_security_group_name)
+      begin
+        promise = @client.network_security_groups.get(resource_group_name, network_security_group_name)
+        response = promise.value!
+        result = response.body
+        result
+        
+        rescue  MsRestAzure::AzureOperationError =>e
+        Chef::Log.error("Error getting NSG '#{network_security_group_name}'")
+        Chef::Log.error("Error Response: #{e.response}")
+        Chef::Log.error("Error Body: #{e.body}")
+        return nil
+      end
+    end
+    
+    def create(resource_group_name, net_sec_group_name, location)
+      begin
+        parameters = Azure::ARM::Network::Models::NetworkSecurityGroup.new
+        parameters.location = location
+
+        nsg_props = NetworkSecurityGroupPropertiesFormat.new
+        parameters.properties = nsg_props
+
+        promise = @client.network_security_groups.create_or_update(resource_group_name,net_sec_group_name,parameters)
+        response = promise.value!
+        result = response.body
+        result
+
+        rescue MsRestAzure::AzureOperationError => e
+        Chef::Log.error("Error  creating network security group in '#{resource_group_name}'")
+        Chef::Log.error("Error response: #{e.response}")
+        Chef::Log.error("Error Body: #{e.body}")
+        return nil
+      end
+    end
+    
+    def create_update(resource_group_name, net_sec_group_name, parameters )
+      begin
+        promise = @client.network_security_groups.create_or_update(resource_group_name,net_sec_group_name,parameters)
+        response = promise.value!
+        result = response.body
+        result
+
+        rescue MsRestAzure::AzureOperationError => e
+        Chef::Log.error("Error  creating network security group in '#{resource_group_name}'")
+        Chef::Log.error("Error response: #{e.response}")
+        Chef::Log.error("Error Body: #{e.body}")
+        return nil
+      end
+    end
+    
+    def list_security_groups(resource_group_name)
+      begin
+        promise = @client.network_security_groups.list(resource_group_name)
+        response = promise.value!
+        result = response.body
+        result
+
+        rescue  MsRestAzure::AzureOperationError => e
+        Chef::Log.error("Error getting network security groups in   '#{resource_group_name}' ")
+        Chef::Log.error("Error Response: #{e.response}")
+        Chef::Log.error("Error Body: #{e.body}")
+        return nil
+      end
+    end
+    
+    def delete_security_group(resource_group_name, net_sec_group_name)
+      begin
+        promise = @client.network_security_groups.delete(resource_group_name, net_sec_group_name)
+        response = promise.value!
+        result = response.body
+        result
+
+        rescue  MsRestAzure::AzureOperationError => e
+        Chef::Log.error("Error deleting NSG #{resource_group_name}")
+        Chef::Log.error("Error Response: #{e.response}")
+        Chef::Log.error("Error Body: #{e.body}")
+        return nil
+      end
+    end
+    
+    def create_or_update_rule(resource_group_name, network_security_group_name, security_rule_name, security_rule_parameters = nil)
+      # The Put network security rule operation creates/updates a security rule in the specified network security group group.
+      begin
+        secrule = SecurityRule.new
+        secrule.properties = security_rule_parameters
+
+        promise = SecurityRules.new(@client).create_or_update(resource_group_name, network_security_group_name, security_rule_name, secrule)
+        response = promise.value!
+        result = response.body
+        result
+
+      rescue  MsRestAzure::AzureOperationError => e
+        Chef::Log.error("Error trying to get the '#{security_rule_name}' Security Rule")
+        Chef::Log.error("Error Response: #{e.response}")
+        Chef::Log.error("Error Body: #{e.body}")
+        return nil
+      end
+    end
+    
+    def delete_rule(resource_group_name, network_security_group_name, security_rule_name)
+      # The delete network security rule operation deletes the specified network security rule.
+      begin
+        promise = SecurityRules.new(@client).delete(resource_group_name, network_security_group_name, security_rule_name)
+        response = promise.value!
+        result = response.body
+        result
+
+      rescue  MsRestAzure::AzureOperationError => e
+        Chef::Log.error("Error trying to delete the '#{security_rule_name}' Security Rule")
+        Chef::Log.error("Error Response: #{e.response}")
+        Chef::Log.error("Error Body: #{e.body}")
+        return nil
+      end
+    end
+    
+    def get_rule(resource_group_name, network_security_group_name, security_rule_name, custom_headers = nil)
+      #The Get NetworkSecurityRule operation retreives information about the specified network security rule.
+      begin
+        promise = SecurityRules.new(@client).get(resource_group_name, network_security_group_name, security_rule_name)
+        response = promise.value!
+        result = response.body
+        result
+
+      rescue  MsRestAzure::AzureOperationError => e
+        Chef::Log.error("Error trying to get the '#{security_rule_name}' Security Rule")
+        Chef::Log.error("Error Response: #{e.response}")
+        Chef::Log.error("Error Body: #{e.body}")
+        return nil
+      end
+    end
+    
+    def list_rules(resource_group_name, network_security_group_name)
+      # The List network security rule opertion retrieves all the security rules in a network security group.
+      begin
+        promise = SecurityRules.new(@client).list(resource_group_name, network_security_group_name)
+        response = promise.value!
+        result = response.body
+        result
+
+      rescue  MsRestAzure::AzureOperationError => e
+        Chef::Log.error("Error trying to listing Security Rules in '#{resource_group_name}' ")
+        Chef::Log.error("Error Response: #{e.response}")
+        Chef::Log.error("Error Body: #{e.body}")
+        return nil
+      end
+    end
+    
+    
+    def self.create_rule_properties(security_rule_name,access,description, destination_address_prefix, destination_port_range,direction, priority, protocol, provisioning_state, source_address_prefix, source_port_range)
+      #01 @security_rule_name ⇒ Security group name
+      #02 @access ⇒ SecurityRuleAccess allow or denied.
+      #03 @description ⇒ String to 140 chars
+      #04 @destination_address_prefix ⇒ String source IP range
+      #05 @destination_port_range ⇒ String range between 0 and 65535.
+      #06 @direction ⇒ SecurityRuleDirection rule.InBound or Outbound.
+      #07 @priority ⇒ Integer be between 100 and 4096.
+      #08 @protocol ⇒ SecurityRuleProtocol applies to.
+      #09 @provisioning_state ⇒ String resource Updating/Deleting/Failed.
+      #10 @source_address_prefix ⇒ String range.
+      #11 @source_port_range ⇒ String between 0 and 65535.
+
+      sec_rule = Azure::ARM::Network::Models::SecurityRule.new
+      sec_rule.name = security_rule_name
+
+      sec_rule_props = Azure::ARM::Network::Models::SecurityRulePropertiesFormat.new
+      sec_rule_props.access = access
+      sec_rule_props.description = description
+      sec_rule_props.destination_address_prefix = destination_address_prefix
+      sec_rule_props.destination_port_range = destination_port_range
+      sec_rule_props.direction = direction
+      sec_rule_props.priority = priority
+      sec_rule_props.protocol = protocol
+      sec_rule_props.provisioning_state = provisioning_state
+      sec_rule_props.source_address_prefix = source_address_prefix
+      sec_rule_props.source_port_range = source_port_range
+
+      sec_rule.properties = sec_rule_props
+      sec_rule
+    end
+
+  #end of class    
+  end
+  #end of module
+end

--- a/components/cookbooks/azure/libraries/network_security_group.rb
+++ b/components/cookbooks/azure/libraries/network_security_group.rb
@@ -19,10 +19,18 @@ module AzureNetwork
         result
         
         rescue  MsRestAzure::AzureOperationError =>e
-        Chef::Log.error("Error getting NSG '#{network_security_group_name}'")
-        Chef::Log.error("Error Response: #{e.response}")
-        Chef::Log.error("Error Body: #{e.body}")
-        return nil
+          Chef::Log.error("Error getting NSG '#{network_security_group_name}'")
+          Chef::Log.error("Error Response: #{e.response}")
+          Chef::Log.error("Error Body: #{e.body}")
+          return nil
+        rescue Exception => e
+          msg = "Exception trying to get network security group #{network_security_group_name} from resource group: #{resource_group_name}"
+          Chef::Log.error("Azure::Network Security group -#{msg}")
+          puts "***FAULT:FATAL="+e.body.to_s
+          Chef::Log.error("Azure::Network Security group - Exception is: #{e.message}")
+          e = Exception.new('no backtrace')
+          e.set_backtrace('')
+          raise e
       end
     end
     
@@ -44,6 +52,14 @@ module AzureNetwork
         Chef::Log.error("Error response: #{e.response}")
         Chef::Log.error("Error Body: #{e.body}")
         return nil
+        rescue Exception => e
+          msg = "Exception trying to create network security group #{network_security_group_name} from resource group: #{resource_group_name}"
+          Chef::Log.error("Azure::Network Security group -#{msg}")
+          puts "***FAULT:FATAL="+e.body.to_s
+          Chef::Log.error("Azure::Network Security group - Exception is: #{e.message}")
+          e = Exception.new('no backtrace')
+          e.set_backtrace('')
+          raise e
       end
     end
     
@@ -59,6 +75,14 @@ module AzureNetwork
         Chef::Log.error("Error response: #{e.response}")
         Chef::Log.error("Error Body: #{e.body}")
         return nil
+        rescue Exception => e
+          msg = "Exception trying to create/update network security group #{network_security_group_name} from resource group: #{resource_group_name}"
+          Chef::Log.error("Azure::Network Security group -#{msg}")
+          puts "***FAULT:FATAL="+e.body.to_s
+          Chef::Log.error("Azure::Network Security group - Exception is: #{e.message}")
+          e = Exception.new('no backtrace')
+          e.set_backtrace('')
+          raise e
       end
     end
     
@@ -74,6 +98,14 @@ module AzureNetwork
         Chef::Log.error("Error Response: #{e.response}")
         Chef::Log.error("Error Body: #{e.body}")
         return nil
+        rescue Exception => e
+          msg = "Exception trying to list network security groups from #{resource_group_name} resource group"
+          Chef::Log.error("Azure::Network Security group -#{msg}")
+          puts "***FAULT:FATAL="+e.body.to_s
+          Chef::Log.error("Azure::Network Security group - Exception is: #{e.message}")
+          e = Exception.new('no backtrace')
+          e.set_backtrace('')
+          raise e
       end
     end
     
@@ -89,6 +121,14 @@ module AzureNetwork
         Chef::Log.error("Error Response: #{e.response}")
         Chef::Log.error("Error Body: #{e.body}")
         return nil
+        rescue Exception => e
+          msg = "Exception trying to delete network security group #{net_sec_group_name} from resource group: #{resource_group_name}"
+          Chef::Log.error("Azure::Network Security group -#{msg}")
+          puts "***FAULT:FATAL="+e.body.to_s
+          Chef::Log.error("Azure::Network Security group - Exception is: #{e.message}")
+          e = Exception.new('no backtrace')
+          e.set_backtrace('')
+          raise e
       end
     end
     
@@ -108,6 +148,14 @@ module AzureNetwork
         Chef::Log.error("Error Response: #{e.response}")
         Chef::Log.error("Error Body: #{e.body}")
         return nil
+      rescue Exception => e
+        msg = "Exception trying to create/update security rule #{security_rule_name} in securtiry group: #{network_security_group_name}"
+        Chef::Log.error("Azure::Network Security group -#{msg}")
+        puts "***FAULT:FATAL="+e.body.to_s
+        Chef::Log.error("Azure::Network Security group - Exception is: #{e.message}")
+        e = Exception.new('no backtrace')
+        e.set_backtrace('')
+        raise e
       end
     end
     
@@ -124,6 +172,14 @@ module AzureNetwork
         Chef::Log.error("Error Response: #{e.response}")
         Chef::Log.error("Error Body: #{e.body}")
         return nil
+      rescue Exception => e
+        msg = "Exception trying to delete security rule #{security_rule_name} from securtiry group: #{network_security_group_name}"
+        Chef::Log.error("Azure::Network Security group -#{msg}")
+        puts "***FAULT:FATAL="+e.body.to_s
+        Chef::Log.error("Azure::Network Security group - Exception is: #{e.message}")
+        e = Exception.new('no backtrace')
+        e.set_backtrace('')
+        raise e
       end
     end
     
@@ -140,6 +196,14 @@ module AzureNetwork
         Chef::Log.error("Error Response: #{e.response}")
         Chef::Log.error("Error Body: #{e.body}")
         return nil
+      rescue Exception => e
+        msg = "Exception trying to get security rule #{security_rule_name} from securtiry group: #{network_security_group_name}"
+        Chef::Log.error("Azure::Network Security group -#{msg}")
+        puts "***FAULT:FATAL="+e.body.to_s
+        Chef::Log.error("Azure::Network Security group - Exception is: #{e.message}")
+        e = Exception.new('no backtrace')
+        e.set_backtrace('')
+        raise e
       end
     end
     
@@ -156,6 +220,14 @@ module AzureNetwork
         Chef::Log.error("Error Response: #{e.response}")
         Chef::Log.error("Error Body: #{e.body}")
         return nil
+      rescue Exception => e
+        msg = "Exception trying to list security rules from securtiry group: #{network_security_group_name}"
+        Chef::Log.error("Azure::Network Security group -#{msg}")
+        puts "***FAULT:FATAL="+e.body.to_s
+        Chef::Log.error("Azure::Network Security group - Exception is: #{e.message}")
+        e = Exception.new('no backtrace')
+        e.set_backtrace('')
+        raise e
       end
     end
     
@@ -194,5 +266,5 @@ module AzureNetwork
 
   #end of class    
   end
-  #end of module
+#end of module
 end

--- a/components/cookbooks/azure/libraries/network_security_group.rb
+++ b/components/cookbooks/azure/libraries/network_security_group.rb
@@ -17,7 +17,6 @@ module AzureNetwork
         response = promise.value!
         result = response.body
         result
-        
         rescue  MsRestAzure::AzureOperationError =>e
           Chef::Log.error("Error getting NSG '#{network_security_group_name}'")
           Chef::Log.error("Error Response: #{e.response}")

--- a/components/cookbooks/azure/recipes/add_net_sec_group.rb
+++ b/components/cookbooks/azure/recipes/add_net_sec_group.rb
@@ -1,0 +1,64 @@
+
+require File.expand_path('../../libraries/network_security_group.rb', __FILE__)
+
+::Chef::Recipe.send(:include, AzureNetwork)
+::Chef::Recipe.send(:include, Azure::ARM::Network)
+::Chef::Recipe.send(:include, Azure::ARM::Network::Models)
+include_recipe "azure::get_credentials"
+include_recipe 'azure::get_platform_rg_and_as'
+
+cloud_name = node['workorder']['cloud']['ciName']
+subscription = node['workorder']['services']['compute'][cloud_name]['ciAttributes']['subscription']
+location = node['workorder']['services']['compute'][cloud_name]['ciAttributes']['location']
+credentials = node['azureCredentials']
+resource_group_name = node['platform-resource-group']
+network_security_group_name = node['name']
+node['secgroup']['inbound']
+
+#Creating security rules objects
+nsg = AzureNetwork::NetworkSecurityGroup.new(credentials,subscription)
+rules = node['secgroup']['inbound'].tr('"[]\\','').split(",")
+sec_rules = Array.new
+priority = 100
+reg_ex = /\d+\s\d+\s([A-Za-z]+|\*)\s\S+/
+rules.each do |item|
+  if !reg_ex.match(item)
+    raise "#{item} is not a valid security rule"
+  end    
+  item2 = item.split(" ")
+  security_rule_access = SecurityRuleAccess::Allow
+  security_rule_description = node['secgroup']['description']
+  security_rule_destination_addres_prefix = item2[3] 
+  security_rule_destination_port_range = item2[1].to_i
+  security_rule_direction = SecurityRuleDirection::Inbound
+  security_rule_priority = priority
+  case item2[2].downcase
+    when 'tcp'
+      security_rule_protocol = SecurityRuleProtocol::Tcp
+    when 'udp'
+      security_rule_protocol = SecurityRuleProtocol::Udp
+    else
+      security_rule_protocol = SecurityRuleProtocol::Asterisk
+  end
+  security_rule_provisioning_state = nil
+  security_rule_source_addres_prefix = '0.0.0.0/0'
+  security_rule_source_port_range = item2[0].to_i
+  security_rule_name = network_security_group_name + "-" +priority.to_s
+  sec_rules << AzureNetwork::NetworkSecurityGroup.create_rule_properties(security_rule_name,security_rule_access,security_rule_description,security_rule_destination_addres_prefix,security_rule_destination_port_range,security_rule_direction,security_rule_priority,security_rule_protocol,security_rule_provisioning_state,security_rule_source_addres_prefix,security_rule_source_port_range)
+  priority += 100
+end
+
+parameters = NetworkSecurityGroup.new
+parameters.location = location
+
+nsg_props = NetworkSecurityGroupPropertiesFormat.new
+nsg_props.security_rules = sec_rules
+parameters.properties = nsg_props
+    
+nsg_result = nsg.create_update(resource_group_name,network_security_group_name,parameters)
+
+if !nsg_result.nil?
+Chef::Log.info("The network security group has been created\n\rid: '#{nsg_result.id}'\n\r'#{nsg_result.location}'\n\r'#{nsg_result.name}'\n\r'#{nsg_result.type}'")
+else
+  raise "Error creating network security group"
+end

--- a/components/cookbooks/azure/spec/network_security_group_spec.rb
+++ b/components/cookbooks/azure/spec/network_security_group_spec.rb
@@ -1,0 +1,53 @@
+require_relative 'spec_helper'
+require_relative 'rspec_constants'
+require 'azure_mgmt_network'
+require File.expand_path('../../libraries/network_security_group.rb', __FILE__)
+
+
+RSpec.describe  do
+
+  def nsg
+    token_provider = MsRestAzure::ApplicationTokenProvider.new(TENANT_ID, CLIENT_ID, CLIENT_SECRET)
+    credentials = MsRest::TokenCredentials.new(token_provider)
+    AzureNetwork::NetworkSecurityGroup.new(credentials,SUBSCRIPTION_ID)
+  end
+  
+  def sec_rule
+    AzureNetwork::NetworkSecurityGroup.create_rule_properties(SECURITY_RULE_NAME,SECURITY_RULE_ACCESS,SECURITY_RULE_DESCRIPTION,SECURITY_RULE_DESTINATION_ADDRESS_PREFIX,SECURITY_RULE_DESTINATION_PORT_RANGE,SECURITY_RULE_DIRECTION,SECURITY_RULE_PRIORITY,SECURITY_RULE_PROTOCOL,SECURITY_RULE_PROVISIONING_STATE,SECURITY_RULE_SOURCE_ADDRESS_PREFIX,SECURITY_RULE_SOURCE_PORT_RANGE)
+  end
+  
+  describe '#create_rule_properties' do
+    context 'fill the parameters' do
+      it 'returns a security rule object' do
+        expect(sec_rule).not_to be_nil
+      end 
+    end
+  end
+
+  describe '#list_security_groups' do
+    context 'when search into a resource group' do
+      it 'response must not be nil' do
+        expect(nsg.list_security_groups(RESOURCE_GROUP)).not_to be_nil
+      end
+    end
+end
+
+  describe '#create_update' do
+    context 'when parameters is not nil' do
+      it 'returns the created/updated network security group' do
+       
+        security_rules = Array.new << sec_rule
+        parameters = NetworkSecurityGroup.new
+        parameters.location = LOCATION
+
+        nsg_props = NetworkSecurityGroupPropertiesFormat.new
+        nsg_props.security_rules = security_rules
+        parameters.properties = nsg_props
+        
+        expect(nsg.create_update(RESOURCE_GROUP,NETWORK_SECURITY_GROUP_NAME,parameters).properties.security_rules[0].name).to eq(SECURITY_RULE_NAME)
+          
+      end      
+    end
+  end
+
+end

--- a/components/cookbooks/secgroup/recipes/add.rb
+++ b/components/cookbooks/secgroup/recipes/add.rb
@@ -20,6 +20,9 @@
 include_recipe "secgroup::setup"
 
 case node[:provider_class]
+when /azure/
+    include_recipe "azure::add_net_sec_group"
+    
 when /ec2|openstack/
   include_recipe "secgroup::add_secgroup_"+node[:provider_class]
 


### PR DESCRIPTION
implementation of azure network security group along with unit test
This functionality will execute in the secgroup step of the deployment.
NOTE: No need to implement delete recipe because the NSG will be deleted when the Resource Group is deleted. In the case of an update, the add recipe will be called and it will automatically recreate all rules.