### PR TITLE
added compute service to base pack

### DIFF
--- a/packs/base.rb
+++ b/packs/base.rb
@@ -680,7 +680,7 @@ resource "hostname",
   :design => true,
   :requires => {
     :constraint => "0..1",
-    :services => "dns",
+    :services => "compute,dns",
     :help => "optional hostname dns entry"
   }           
            


### PR DESCRIPTION
This change is necessary because hostname component is looking for the cloud location/region.
The compute component has that info.