### PR TITLE
added references to DNS class

### DIFF
--- a/components/cookbooks/azuredns/recipes/remove_old_aliases.rb
+++ b/components/cookbooks/azuredns/recipes/remove_old_aliases.rb
@@ -1,5 +1,7 @@
 require File.expand_path('../../libraries/dns.rb', __FILE__)
 
+::Chef::Recipe.send(:include, AzureDns)
+
 # get platform resource group and availability set
 include_recipe 'azure::get_platform_rg_and_as'
 

--- a/components/cookbooks/azuredns/recipes/set_dns_records.rb
+++ b/components/cookbooks/azuredns/recipes/set_dns_records.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../libraries/record_set.rb', __FILE__)
 require File.expand_path('../../libraries/zone.rb', __FILE__)
+require File.expand_path('../../libraries/dns.rb', __FILE__)
 
 ::Chef::Recipe.send(:include, AzureDns)
 


### PR DESCRIPTION
This is a bug fix. Deployments were failing because the is no reference to the DNS class.