### PR TITLE
bug fix for setting the label on the public ip for azure

### DIFF
--- a/components/cookbooks/azuredns/recipes/update_dns_on_pip.rb
+++ b/components/cookbooks/azuredns/recipes/update_dns_on_pip.rb
@@ -1,7 +1,7 @@
+require 'azure_mgmt_network'
 require File.expand_path('../../../azure/libraries/azure_utils.rb', __FILE__)
+require File.expand_path('../../libraries/public_ip.rb', __FILE__)
 
-::Chef::Recipe.send(:include, AzureNetwork)
-::Chef::Recipe.send(:include, Utils)
 ::Chef::Recipe.send(:include, Azure::ARM::Network)
 ::Chef::Recipe.send(:include, Azure::ARM::Network::Models)
 


### PR DESCRIPTION
recipe wouldn't compile due to uninitialized errors.  updated the require and include statements to fix it.