### PR TITLE
removed is_primary flag to create logical volumes on cinder and other non-ephemeral storage in redundant mode.

### DIFF
--- a/components/cookbooks/volume/recipes/add.rb
+++ b/components/cookbooks/volume/recipes/add.rb
@@ -60,11 +60,6 @@ node.set["raid_device"] = raid_device
 platform_name = node.workorder.box.ciName
 logical_name = node.workorder.rfcCi.ciName
 
-is_primary = true
-if node.workorder.rfcCi.ciName[-1,1] != "1"
-  is_primary = false
-end
-
 is_single = true
 if node.workorder.box[:ciAttributes][:availability] != "single"
   is_single = false
@@ -74,13 +69,10 @@ cloud_name = node[:workorder][:cloud][:ciName]
 token_class = node[:workorder][:services][:compute][cloud_name][:ciClassName].split(".").last.downcase
 include_recipe "shared::set_provider"
 
-storage_provider = node.storage_provider_class
-
-if node[:storage_provider_class] =~ /azure/ && !storage.nil?
-  include_recipe "azuredatadisk::attach_datadisk"
-end
 
 # need ruby block so package resource above run first
+
+
 ruby_block 'create-iscsi-volume-ruby-block' do
   block do
 
@@ -88,26 +80,19 @@ ruby_block 'create-iscsi-volume-ruby-block' do
     Chef::Log.info("Storage: "+storage.inspect.gsub("\n"," "))
     Chef::Log.info("------------------------------------------------------")
 
-    if storage.nil?
-       Chef::Log.info("no DependsOn Storage - skipping")
-    else
-      dev_list = ""
-      if node[:storage_provider_class] =~ /azure/
-        Chef::Log.info(" the storage device is already attached")
-        vols = Array.new
-        node[:device_maps].each do |dev_vol|
-          vol_id = dev_vol.split(":")[3]
-          dev_id = dev_vol.split(":")[4]
-          vols.push dev_id
-          dev_list += dev_id+" "
-        end
-      else
-        provider = node[:iaas_provider]
-        storage_provider = node[:storage_provider]
 
-        instance_id = node.workorder.payLoad.ManagedVia[0]["ciAttributes"]["instance_id"]
-        Chef::Log.info("instance_id: "+instance_id)
-        compute = provider.servers.get(instance_id)
+    if storage.nil?
+
+       Chef::Log.info("no DependsOn Storage - skipping")
+
+    else
+
+      provider = node[:iaas_provider]
+      storage_provider = node[:storage_provider]
+
+      instance_id = node.workorder.payLoad.ManagedVia[0]["ciAttributes"]["instance_id"]
+      Chef::Log.info("instance_id: "+instance_id)
+      compute = provider.servers.get(instance_id)
 
       device_maps = storage['ciAttributes']['device_map'].split(" ")
       vols = Array.new
@@ -256,9 +241,6 @@ ruby_block 'create-iscsi-volume-ruby-block' do
             vol.device = dev_id.gsub("xvd","sd")
             vol.server = compute
 
-            when /azure/
-              Chef::Log.info(" the storage device is already attached")
-
           end
         rescue Fog::Compute::AWS::Error=>e
           if e.message =~ /VolumeInUse/
@@ -303,8 +285,6 @@ ruby_block 'create-iscsi-volume-ruby-block' do
 
       end
 
-      end
-
       mode = "raid10"
       if node.workorder.rfcCi.ciAttributes.has_key?("mode")
         mode = node.workorder.rfcCi.ciAttributes["mode"]
@@ -312,7 +292,6 @@ ruby_block 'create-iscsi-volume-ruby-block' do
       level = mode.gsub("raid","")
       has_created_raid = false
       exec_count = 0
-      max_retry = 10
 
       if vols.size > 1
 
@@ -341,9 +320,8 @@ ruby_block 'create-iscsi-volume-ruby-block' do
            Chef::Log.info(`#{ccmd}`)
          end
        end
-       node.set["raid_device"] = raid_device
      else
-      Chef::Log.info("No Raid Device ID :" +no_raid_device)
+      Chef::Log.info ("No Raid Device ID :" +no_raid_device)
       raid_device = no_raid_device
       node.set["raid_device"] = no_raid_device
 
@@ -459,29 +437,19 @@ ruby_block 'create-ephemeral-volume-ruby-block' do
   end
 end
 
-ruby_block 'create-storage-non-ephemeral-volume' do
-  only_if { storage != nil && is_primary && token_class !~ /virtualbox|vagrant/ }
+ruby_block 'create-storage-ebs-volume' do
+  only_if { storage != nil && token_class !~ /virtualbox|vagrant/}
   block do
 
    raid_device = node.raid_device
+
     devices = Array.new
     if ::File.exists?(raid_device)
       Chef::Log.info(raid_device+" exists.")
       devices.push(raid_device)
     else
-      Chef::Log.info("raid device " +raid_device+" missing.")
-      if node[:storage_provider_class] =~ /azure/
-        Chef::Log.info("Checking for"+ node[:device] + "....")
-        if ::File.exists?(node[:device])
-          Chef::Log.info("device "+node[:device]+" found. Using this device for logical volumes.")
-          devices.push(node[:device])
-        else
-          Chef::Log.info("No storage device named " +node[:device]+" found. Exiting ...")
-          exit 1
-        end
-      else
-        exit 1
-      end
+      Chef::Log.info(raid_device+" missing.")
+      exit 1
     end
 
     total_size = 0
@@ -511,8 +479,7 @@ ruby_block 'create-storage-non-ephemeral-volume' do
 
     `lvdisplay /dev/#{platform_name}/#{logical_name}`
     if $?.to_i != 0
-      # pipe yes to agree to clear filesystem signature
-      cmd = "yes | lvcreate #{l_switch} #{size} -n #{logical_name} #{platform_name}"
+      cmd = "lvcreate #{l_switch} #{size} -n #{logical_name} #{platform_name}"
       Chef::Log.info("running: #{cmd} ..."+`#{cmd}`)
       if $? != 0
         Chef::Log.error("error in lvcreate")
@@ -569,7 +536,7 @@ ruby_block 'filesystem' do
     # result attr updates cms
     Chef::Log.info("***RESULT:device="+_device)
 
-    if is_primary || _device =~ /-eph\//
+    if _device =~ /-eph\//
 
       `mountpoint -q #{_mount_point}`
       if $?.to_i == 0
@@ -611,7 +578,7 @@ ruby_block 'filesystem' do
 	end
         `mv /tmp/fstab /etc/fstab`
       else
-       Chef::Log.info("non-single platform w/ ebs - letting crm / resouce mgmt mount")
+       Chef::Log.info("non-single platform w/ block storage - letting crm / resouce mgmt mount")
       end
 
       	if token_class =~ /azure/

--- a/components/cookbooks/volume/recipes/add.rb
+++ b/components/cookbooks/volume/recipes/add.rb
@@ -69,10 +69,13 @@ cloud_name = node[:workorder][:cloud][:ciName]
 token_class = node[:workorder][:services][:compute][cloud_name][:ciClassName].split(".").last.downcase
 include_recipe "shared::set_provider"
 
+storage_provider = node.storage_provider_class
+
+if node[:storage_provider_class] =~ /azure/ && !storage.nil?
+  include_recipe "azuredatadisk::attach_datadisk"
+end
 
 # need ruby block so package resource above run first
-
-
 ruby_block 'create-iscsi-volume-ruby-block' do
   block do
 
@@ -80,19 +83,26 @@ ruby_block 'create-iscsi-volume-ruby-block' do
     Chef::Log.info("Storage: "+storage.inspect.gsub("\n"," "))
     Chef::Log.info("------------------------------------------------------")
 
-
     if storage.nil?
-
        Chef::Log.info("no DependsOn Storage - skipping")
-
     else
+      dev_list = ""
+      if node[:storage_provider_class] =~ /azure/
+        Chef::Log.info(" the storage device is already attached")
+        vols = Array.new
+        node[:device_maps].each do |dev_vol|
+          vol_id = dev_vol.split(":")[3]
+          dev_id = dev_vol.split(":")[4]
+          vols.push dev_id
+          dev_list += dev_id+" "
+        end
+      else
+        provider = node[:iaas_provider]
+        storage_provider = node[:storage_provider]
 
-      provider = node[:iaas_provider]
-      storage_provider = node[:storage_provider]
-
-      instance_id = node.workorder.payLoad.ManagedVia[0]["ciAttributes"]["instance_id"]
-      Chef::Log.info("instance_id: "+instance_id)
-      compute = provider.servers.get(instance_id)
+        instance_id = node.workorder.payLoad.ManagedVia[0]["ciAttributes"]["instance_id"]
+        Chef::Log.info("instance_id: "+instance_id)
+        compute = provider.servers.get(instance_id)
 
       device_maps = storage['ciAttributes']['device_map'].split(" ")
       vols = Array.new
@@ -241,6 +251,9 @@ ruby_block 'create-iscsi-volume-ruby-block' do
             vol.device = dev_id.gsub("xvd","sd")
             vol.server = compute
 
+            when /azure/
+              Chef::Log.info(" the storage device is already attached")
+
           end
         rescue Fog::Compute::AWS::Error=>e
           if e.message =~ /VolumeInUse/
@@ -285,6 +298,8 @@ ruby_block 'create-iscsi-volume-ruby-block' do
 
       end
 
+      end
+
       mode = "raid10"
       if node.workorder.rfcCi.ciAttributes.has_key?("mode")
         mode = node.workorder.rfcCi.ciAttributes["mode"]
@@ -292,6 +307,7 @@ ruby_block 'create-iscsi-volume-ruby-block' do
       level = mode.gsub("raid","")
       has_created_raid = false
       exec_count = 0
+      max_retry = 10
 
       if vols.size > 1
 
@@ -320,8 +336,9 @@ ruby_block 'create-iscsi-volume-ruby-block' do
            Chef::Log.info(`#{ccmd}`)
          end
        end
+       node.set["raid_device"] = raid_device
      else
-      Chef::Log.info ("No Raid Device ID :" +no_raid_device)
+      Chef::Log.info("No Raid Device ID :" +no_raid_device)
       raid_device = no_raid_device
       node.set["raid_device"] = no_raid_device
 
@@ -437,19 +454,29 @@ ruby_block 'create-ephemeral-volume-ruby-block' do
   end
 end
 
-ruby_block 'create-storage-ebs-volume' do
-  only_if { storage != nil && token_class !~ /virtualbox|vagrant/}
+ruby_block 'create-storage-non-ephemeral-volume' do
+  only_if { storage != nil && token_class !~ /virtualbox|vagrant/ }
   block do
 
    raid_device = node.raid_device
-
     devices = Array.new
     if ::File.exists?(raid_device)
       Chef::Log.info(raid_device+" exists.")
       devices.push(raid_device)
     else
-      Chef::Log.info(raid_device+" missing.")
-      exit 1
+      Chef::Log.info("raid device " +raid_device+" missing.")
+      if node[:storage_provider_class] =~ /azure/
+        Chef::Log.info("Checking for"+ node[:device] + "....")
+        if ::File.exists?(node[:device])
+          Chef::Log.info("device "+node[:device]+" found. Using this device for logical volumes.")
+          devices.push(node[:device])
+        else
+          Chef::Log.info("No storage device named " +node[:device]+" found. Exiting ...")
+          exit 1
+        end
+      else
+        exit 1
+      end
     end
 
     total_size = 0
@@ -479,7 +506,8 @@ ruby_block 'create-storage-ebs-volume' do
 
     `lvdisplay /dev/#{platform_name}/#{logical_name}`
     if $?.to_i != 0
-      cmd = "lvcreate #{l_switch} #{size} -n #{logical_name} #{platform_name}"
+      # pipe yes to agree to clear filesystem signature
+      cmd = "yes | lvcreate #{l_switch} #{size} -n #{logical_name} #{platform_name}"
       Chef::Log.info("running: #{cmd} ..."+`#{cmd}`)
       if $? != 0
         Chef::Log.error("error in lvcreate")
@@ -578,7 +606,7 @@ ruby_block 'filesystem' do
 	end
         `mv /tmp/fstab /etc/fstab`
       else
-       Chef::Log.info("non-single platform w/ block storage - letting crm / resouce mgmt mount")
+       Chef::Log.info("non-single platform w/ non-ephemeral storage - letting crm / resouce mgmt mount")
       end
 
       	if token_class =~ /azure/


### PR DESCRIPTION
removed is_primary flag to create logical volumes on cinder and other external storage in all the computes in redundant mode.