### PR TITLE
Fix - add jdk mirror service for oracle java

### DIFF
--- a/components/cookbooks/java/recipes/oracle.rb
+++ b/components/cookbooks/java/recipes/oracle.rb
@@ -54,7 +54,6 @@ if node.java.binpath.empty?
     group 'root'
     mode 0755
     source "#{base_url}/#{file_name}"
-    action :create_if_missing
   end
 
 else

--- a/packs/activemq.rb
+++ b/packs/activemq.rb
@@ -110,20 +110,21 @@ resource 'activemq',
       }
     }
 
-resource "java",
-    :cookbook => "oneops.1.java",
-    :design => true,
-    :requires => {
-      :constraint => '1..1',
-      :help => 'Java Programming Language Environment'
-    },
-    :attributes => {
-      :install_dir => "/usr/lib/jvm",
-      :jrejdk => "jdk",
-      :version => "7",
-      :sysdefault => "true",
-      :flavor => "openjdk"
-    }
+resource 'java',
+         :cookbook => 'oneops.1.java',
+         :design => true,
+         :requires => {
+             :constraint => '1..1',
+             :services => '*mirror',
+             :help => 'Java Programming Language Environment'
+         },
+         :attributes => {
+             :install_dir => '/usr/lib/jvm',
+             :jrejdk => 'jdk',
+             :version => '7',
+             :sysdefault => 'true',
+             :flavor => 'openjdk'
+         }
 
 resource "vol-data",
     :cookbook => "oneops.1.volume",

--- a/packs/cassandra.rb
+++ b/packs/cassandra.rb
@@ -167,19 +167,22 @@ resource "artifact",
          }
 
 resource "keyspace",
-  :cookbook => "oneops.1.keyspace",
-  :design => true,
-  :requires => { "constraint" => "0..*"},
-  :attributes => {
-  }
+         :cookbook => "oneops.1.keyspace",
+         :design => true,
+         :requires => {"constraint" => "0..*"},
+         :attributes => {
+         }
 
-resource "java",
-  :cookbook => "oneops.1.java",
-  :design => true,
-  :requires => { "constraint" => "0..1"},
-  :attributes => {
-  }
-  
+resource 'java',
+         :cookbook => 'oneops.1.java',
+         :design => true,
+         :requires => {
+             :constraint => '0..1',
+             :services => '*mirror',
+             :help => 'Java Programming Language Environment'
+         },
+         :attributes => {}
+
 resource "secgroup",
          :cookbook => "oneops.1.secgroup",
          :design => true,

--- a/packs/custom.rb
+++ b/packs/custom.rb
@@ -42,21 +42,24 @@ resource "secgroup",
              :constraint => "1..1",
              :services => "compute"
          }
-         
+
 resource "artifact",
-  :cookbook => "oneops.1.artifact",
-  :design => true,
-  :requires => { "constraint" => "0..*" },
-  :attributes => {
-
-  }
-
-resource "java",
-         :cookbook => "oneops.1.java",
+         :cookbook => "oneops.1.artifact",
          :design => true,
-         :requires => { "constraint" => "0..1"},
+         :requires => {"constraint" => "0..*"},
          :attributes => {
+
          }
+
+resource 'java',
+         :cookbook => 'oneops.1.java',
+         :design => true,
+         :requires => {
+             :constraint => '0..1',
+             :services => '*mirror',
+             :help => 'Java Programming Language Environment'
+         },
+         :attributes => {}
 
 resource "keystore",
          :cookbook => "oneops.1.keystore",

--- a/packs/docker.rb
+++ b/packs/docker.rb
@@ -69,7 +69,7 @@ resource 'java',
          :design => true,
          :requires => {
              :constraint => '0..1',
-             :services => 'mirror',
+             :services => '*mirror',
              :help => 'Java Programming Language Environment'
          },
          :attributes => {}

--- a/packs/es.rb
+++ b/packs/es.rb
@@ -34,16 +34,16 @@ resource 'volume',
                          'options' => ''
          }
 
-resource "java",
-  :cookbook => "oneops.1.java",
-  :design => true,
-  :requires => {
-    :constraint => "0..1",
-    :help => "java programming language environment"
-  },
-  :attributes => {
+resource 'java',
+         :cookbook => 'oneops.1.java',
+         :design => true,
+         :requires => {
+             :constraint => '0..1',
+             :services => '*mirror',
+             :help => 'Java Programming Language Environment'
+         },
+         :attributes => {}
 
-  }
 
 resource 'elasticsearch',
          :cookbook => 'oneops.1.es',

--- a/packs/flamegraph.rb
+++ b/packs/flamegraph.rb
@@ -222,22 +222,22 @@ resource "user-app",
 
 
 resource "java",
-	  :cookbook => "oneops.1.java",
-	  :design => true,
-	  :requires => {
-	  	:constraint => "1..1",
-		:services => "mirror",
-		:help => "Java Programming Language Environment"
-          },
-	  :attributes => {
-	  	:install_dir => "/usr/lib/jvm",
-	  	:flavor => "oracle",
-	        :jrejdk => "jdk",
-		:version => "8",
-		:uversion => "66",
-		:binpath => "",
-		:sysdefault => "true"
-	  }
+				 :cookbook => "oneops.1.java",
+				 :design => true,
+				 :requires => {
+						 :constraint => "1..1",
+						 :services => "mirror",
+						 :help => "Java Programming Language Environment"
+				 },
+				 :attributes => {
+						 :install_dir => "/usr/lib/jvm",
+						 :flavor => "oracle",
+						 :jrejdk => "jdk",
+						 :version => "8",
+						 :uversion => "66",
+						 :binpath => "",
+						 :sysdefault => "true"
+				 }
 
 # depends_on
 [ { :from => 'nginx',  :to => 'compute' },

--- a/packs/java.rb
+++ b/packs/java.rb
@@ -8,24 +8,22 @@ category "Worker Application"
 environment "single", {}
 environment "redundant", {}
 
-resource "java",
-  :cookbook => "oneops.1.java",
-  :design => true,
-  :requires => {
-    :constraint => "1..1",
-    :help => "java programming language environment",
-    :services => 'mirror'
-  },
-  :attributes => {
-
-  }
+resource 'java',
+         :cookbook => 'oneops.1.java',
+         :design => true,
+         :requires => {
+             :constraint => '1..1',
+             :services => 'mirror',
+             :help => 'Java Programming Language Environment'
+         },
+         :attributes => {}
 
 resource "secgroup",
          :cookbook => "oneops.1.secgroup",
          :design => true,
          :attributes => {
-       	     "inbound" => '[ "22 22 tcp 0.0.0.0/0" ]'
-	 },
+             "inbound" => '[ "22 22 tcp 0.0.0.0/0" ]'
+         },
          :requires => {
              :constraint => "1..1",
              :services => "compute"

--- a/packs/jboss.rb
+++ b/packs/jboss.rb
@@ -103,17 +103,17 @@ resource "secgroup",
     :services => "compute"
   }
 
-resource "java",
-  :cookbook => "oneops.1.java",
-  :design => true,
-  :requires => {
-    :constraint => "1..1",
-    :help => "java programming language environment"
-  },
-  :attributes => {
-  :version => '7'
-  }
-
+resource 'java',
+         :cookbook => 'oneops.1.java',
+         :design => true,
+         :requires => {
+             :constraint => '1..1',
+             :services => '*mirror',
+             :help => 'Java Programming Language Environment'
+         },
+         :attributes => {
+             :version => '7'
+         }
 
 # depends_on
 [ { :from => 'jboss',     :to => 'os' },

--- a/packs/play.rb
+++ b/packs/play.rb
@@ -108,16 +108,15 @@ resource "secgroup",
              :services => "compute"
          }
 
-resource "java",
-  :cookbook => "oneops.1.java",
-  :design => true,
-  :requires => {
-    :constraint => "1..1",
-    :help => "java programming language environment"
-  },
-  :attributes => {
-
-  }
+resource 'java',
+         :cookbook => 'oneops.1.java',
+         :design => true,
+         :requires => {
+             :constraint => '1..1',
+             :services => '*mirror',
+             :help => 'Java Programming Language Environment'
+         },
+         :attributes => {}
  
 resource "volume-log",
   :cookbook => "oneops.1.volume",

--- a/packs/solrcloud.rb
+++ b/packs/solrcloud.rb
@@ -31,6 +31,7 @@ resource "java",
          :design => true,
          :requires => {
              :constraint => "1..1",
+             :services => "*mirror",
              :help => "Java Programming Language Environment"
          },
          :attributes => {

--- a/packs/tomcat.rb
+++ b/packs/tomcat.rb
@@ -202,7 +202,7 @@ resource "build",
     "migration_command" => '',
     "restart_command"   => ''
   }
-  
+
 resource "secgroup",
          :cookbook => "oneops.1.secgroup",
          :design => true,
@@ -214,44 +214,43 @@ resource "secgroup",
              :services => "compute"
          }
 
-resource "java",
-  :cookbook => "oneops.1.java",
-  :design => true,
-  :requires => {
-    :constraint => "1..1",
-    :help => "java programming language environment"
-  },
-  :attributes => {
+resource 'java',
+         :cookbook => 'oneops.1.java',
+         :design => true,
+         :requires => {
+             :constraint => '1..1',
+             :services => '*mirror',
+             :help => 'Java Programming Language Environment'
+         },
+         :attributes => {}
 
-  }
-  
-  
+
 # depends_on
-[ { :from => 'tomcat',     :to => 'os' },  
+[ { :from => 'tomcat',     :to => 'os' },
   { :from => 'tomcat',     :to => 'user'  },
   { :from => 'tomcat-daemon',     :to => 'compute' },
   { :from => 'tomcat',     :to => 'java'  },
   { :from => 'artifact',   :to => 'library' },
   { :from => 'artifact',   :to => 'tomcat'  },
-  { :from => 'artifact',   :to => 'download'}, 
+  { :from => 'artifact',   :to => 'download'},
   { :from => 'artifact',   :to => 'build'},
   { :from => 'artifact',   :to => 'volume'},
   { :from => 'build',      :to => 'library' },
   { :from => 'build',      :to => 'tomcat'  },
   { :from => 'build',      :to => 'download'},
-  { :from => 'daemon',     :to => 'artifact' },  
-  { :from => 'daemon',     :to => 'build' },  
+  { :from => 'daemon',     :to => 'artifact' },
+  { :from => 'daemon',     :to => 'build' },
   { :from => 'java',       :to => 'compute' },
   { :from => 'java',       :to => 'os' },
-  {:from => 'keystore', :to => 'certificate'},
-  {:from => 'keystore', :to => 'java'},
-  {:from => 'tomcat', :to => 'keystore'},
+  {:from => 'keystore',    :to => 'certificate'},
+  {:from => 'keystore',    :to => 'java'},
+  {:from => 'tomcat',      :to => 'keystore'},
   { :from => 'java',       :to => 'download'},  ].each do |link|
   relation "#{link[:from]}::depends_on::#{link[:to]}",
     :relation_name => 'DependsOn',
     :from_resource => link[:from],
     :to_resource   => link[:to],
-    :attributes    => { "flex" => false, "min" => 1, "max" => 1 } 
+    :attributes    => { "flex" => false, "min" => 1, "max" => 1 }
 end
 
 relation "tomcat-daemon::depends_on::artifact",

--- a/packs/zookeeper.rb
+++ b/packs/zookeeper.rb
@@ -75,15 +75,15 @@ resource "user-zookeeper",
              "sudoer" => true
          }
 
-resource "java",
-         :cookbook => "oneops.1.java",
+resource 'java',
+         :cookbook => 'oneops.1.java',
          :design => true,
          :requires => {
-             :constraint => "1..1",
-             :help => "Java Programming Language Environment"
+             :constraint => '1..1',
+             :services => '*mirror',
+             :help => 'Java Programming Language Environment'
          },
-         :attributes => {
-          }
+         :attributes => {}
 
 resource "hostname",
         :cookbook => "oneops.1.fqdn",


### PR DESCRIPTION
JRE/JDK/Server-JRE installation from a mirror location was broken. This PR is to support the java installation (ex:  oracle java) from a location configured in the mirror service. 

Mirror service can be configured as, 

`jdk` : `http://<mirror>/some/path/$flavor/$jrejdk/$version/` (using default oracle jdk binary name convention) or `jdk` : `http://<mirror>/some/path/$flavor/$jrejdk/$version/$jrejdk-$version-$arch.$extn`

Also added the optional mirror service to all existing java packs.