### PR TITLE
Bug fix: Removing unwanted check on the services list which caused packs like activemq to fail with azuredatadisk

### DIFF
--- a/components/cookbooks/azuredatadisk/libraries/attachdisk.rb
+++ b/components/cookbooks/azuredatadisk/libraries/attachdisk.rb
@@ -56,6 +56,8 @@ module AzureStorage
         return true
       rescue  MsRestAzure::AzureOperationError =>e
           OOLog.fatal(e.body)
+      rescue MsRestAzure::CloudErrorData =>e
+          OOLog.fatal(e.body.message)
       rescue Exception => ex
           OOLog.fatal(ex.message)
       end

--- a/components/cookbooks/azuredatadisk/recipes/attach_datadisk.rb
+++ b/components/cookbooks/azuredatadisk/recipes/attach_datadisk.rb
@@ -23,15 +23,8 @@ node.workorder.payLoad[:DependsOn].each do |dep|
   end
 end
 
-if node.workorder.services.has_key?("storage")
-  cloud_name = node[:workorder][:cloud][:ciName]
-  storage_service = node[:workorder][:services][:storage][cloud_name]
-  storage = storage_service["ciAttributes"]
-  device_maps = storage['ciAttributes']['device_map'].split(" ")
-  OOLog.info("device_maps"+device_maps)
-  node.set[:device_maps] = device_maps
 
-elsif storage != nil
+if storage != nil
   attr = storage[:ciAttributes]
   OOLog.info("attr"+attr.inspect())
   device_maps = attr['device_map'].split(" ")


### PR DESCRIPTION
Removing unwanted check on the services list which caused packs like activemq to fail with azuredatadisk