### PR TITLE
Reopen #245: add initial_user to openstack compute

### DIFF
--- a/clouds/openstack.rb
+++ b/clouds/openstack.rb
@@ -21,7 +21,7 @@ image_map = '{"ubuntu-14.04":"",
               "fedora-19":""}'
 
 repo_map = '{
-      "centos-7.0":"yum -d0 -e0 -y install rsync; rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/epel-release-6-8.noarch.rpm",
+      "centos-7.0":"yum -d0 -e0 -y install rsync epel-release",
       "centos-6.5":"yum -d0 -e0 -y install rsync; rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm",
       "centos-6.4":"yum -d0 -e0 -y install rsync; rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm",
       "centos-6.2":"yum -d0 -e0 -y install rsync; rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm"

--- a/components/cookbooks/compute/recipes/add_node_openstack.rb
+++ b/components/cookbooks/compute/recipes/add_node_openstack.rb
@@ -530,3 +530,10 @@ ruby_block 'handle ssh port closed' do
     
   end
 end
+
+if compute_service.has_key?("initial_user") && !compute_service[:initial_user].empty?
+  node.set["use_initial_user"] = true
+  initial_user = compute_service[:initial_user]
+  # put initial_user on the node for the following recipes
+  node.set[:initial_user] = initial_user
+end

--- a/components/cookbooks/openstack/metadata.rb
+++ b/components/cookbooks/openstack/metadata.rb
@@ -192,6 +192,15 @@ attribute 'ostype',
       ['Fedora 19','fedora-19']] }
   }
 
+attribute 'initial_user',
+  :description => "Initial UserName",
+  :default => '',
+  :format => {
+  :help => 'Initial UserName to use for computes',
+  :category => '4.Operating System',
+  :order => 5
+  }
+
 # limits
 attribute 'max_instances',
   :description => "Max Total Instances",


### PR DESCRIPTION
added the check for compute_service.has_key?("initial_user")

Tested on trystack.org