### PR TITLE
Fix json.gem installation and OpenStack floating ip recognition

### DIFF
--- a/components/cookbooks/compute/files/default/install_base.sh
+++ b/components/cookbooks/compute/files/default/install_base.sh
@@ -128,7 +128,7 @@ if [ -e /etc/redhat-release ] ; then
    fi	
 fi
 
-gem install json-1.7.7 --no-ri --no-rdoc
+gem install json --version 1.7.7 --no-ri --no-rdoc
 if [ $? -ne 0 ]; then
     echo "gem install using local repo failed. reverting to rubygems proxy."
     gem source --add $rubygems_proxy

--- a/components/cookbooks/compute/recipes/add_node_openstack.rb
+++ b/components/cookbooks/compute/recipes/add_node_openstack.rb
@@ -379,20 +379,20 @@ ruby_block 'set node network params' do
         
         addrs = server.addresses[network_name]
         addrs_map = {}
-        # some case openstack returns 2 of same addr
+        # some time openstack returns 2 of same addr
         addrs.each do |addr|
+          next if ( addr.has_key? "OS-EXT-IPS:type" && addr["OS-EXT-IPS:type"] != "fixed" )
           ip = addr['addr']
+          if addrs_map.has_key? ip
+            puts "***FAULT:FATAL=The same ip #{ip} returned multiple times"
+            e = Exception.new("no backtrace")
+            e.set_backtrace("")
+            raise e
+          end
           addrs_map[ip] = 1
         end
-        if addrs_map.keys.size > 1
-          puts "***FAULT:FATAL=multiple ips returned"
-          e = Exception.new("no backtrace")
-          e.set_backtrace("")
-          raise e
-        end
-        public_ip = addrs.first["addr"] 
-        private_ip = public_ip
-        node.set[:ip] = public_ip
+        private_ip = addrs.first["addr"]
+        node.set[:ip] = private_ip
       end
     end
     


### PR DESCRIPTION
- json.gem issue:
  Migrated to a new 'gem install' command format.

- OpenStack Floating IP issue:
  Mirantis OpenStack 8.0 (Liberty based) was used. The original code didn't pick up a floating IP as a public IP. That leaded to absence of connectivity from OneOps node to a VM instance.
