### PR TITLE
removed install_software call when add does same

### DIFF
--- a/components/cookbooks/cassandra/recipes/replace.rb
+++ b/components/cookbooks/cassandra/recipes/replace.rb
@@ -1,8 +1,5 @@
 # cassandra replace
 
-include_recipe 'cassandra::install_software'
-
-
 ruby_block "replace_address option" do
   block do
     


### PR DESCRIPTION
In replace recipe, there is no need to call install_software when add does the same. hence removed.