### PR TITLE
fix bug when resource group already exists

### DIFF
--- a/components/cookbooks/azure_base/libraries/resource_group_manager.rb
+++ b/components/cookbooks/azure_base/libraries/resource_group_manager.rb
@@ -51,7 +51,7 @@ module AzureBase
                                                      resource_group).value!
           return response
         else
-          return rg
+          OOLog.info("Resource Group, #{@rg_name} already exists.  Moving on...")
         end
       rescue MsRestAzure::AzureOperationError => e
         OOLog.fatal("Error creating resource group: #{e.body}")


### PR DESCRIPTION
Instead of returning a variable that hasn't been initialized, we will just log that the resource group exists and move on.