### PR TITLE
changed the network name from vnet_<resource_group> to vnet_<network_…

### DIFF
--- a/components/cookbooks/azure/libraries/network_interface_card.rb
+++ b/components/cookbooks/azure/libraries/network_interface_card.rb
@@ -126,7 +126,7 @@ module AzureNetwork
         # fail if we can't find a vnet
         OOLog.fatal('Expressroute requires preconfigured networks') if network.nil?
       else
-        network_name = 'vnet_'+ @rg_name
+        network_name = 'vnet_'+ network_address.gsub('.','_').gsub('/', '_')
         OOLog.info("Using RG: '#{@rg_name}' to find vnet: '#{network_name}'")
         virtual_network.name = network_name
         # network = virtual_network.get(@rg_name)


### PR DESCRIPTION
…address>.  reason: the network name max length is 70 characters while the resource group name max lentgh is 90, so network_create errors out when resource_group greather than 70.