### PR TITLE
propagation rule b/w fqdn and lb in both direction

### DIFF
--- a/packs/genericlb.rb
+++ b/packs/genericlb.rb
@@ -89,5 +89,5 @@ end
     :relation_name => 'DependsOn',
     :from_resource => from,
     :to_resource   => 'lb',
-    :attributes    => { "propagate_to" => 'to', "flex" => false, "min" => 1, "max" => 1 }
+    :attributes    => { "propagate_to" => 'both', "flex" => false, "min" => 1, "max" => 1 }
 end


### PR DESCRIPTION
upon LB replacement, the LB endpoints in FQDN will not be updated, if the propagation is just one direction.

Please refer to a similar case `lbdb.rb`: https://github.com/oneops/circuit-oneops-1/blob/master/packs/lbdb.rb#L195-L202