### PR TITLE
Add check_port attribute to haproxy

### DIFF
--- a/components/cookbooks/haproxy/metadata.rb
+++ b/components/cookbooks/haproxy/metadata.rb
@@ -160,7 +160,15 @@ attribute 'options',
     :order => 10
   }         
   
-             
+attribute 'check_port',
+   :description => "Check Port",
+   :default => "",
+   :format => {
+   :help => 'Handshake check',
+   :category => '1.Config',
+   :order => 11
+  }
+
     
 attribute 'override_config',
   :description => "Override Config Content",

--- a/components/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/components/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -53,19 +53,24 @@ defaults
 <%
 platform_name =  node.workorder.box.ciName
 %>
-        
+
 #
 # platform <%= platform_name %>
 #
+
 <% JSON.parse(node.haproxy.listeners).each_pair do |external_port,internal_port| %>
 frontend <%= platform_name %>-<%= external_port %>
        bind *:<%= external_port %>
        default_backend <%= platform_name %>-<%= internal_port %>
 
+<%
+check_port = node.haproxy.check_port == "" ? internal_port : node.haproxy.check_port
+%>
+
 backend <%= platform_name %>-<%= internal_port %>
        balance <%= node.haproxy.lbmethod %>
   <% node.workorder.payLoad.RequiresComputes.each do |member| -%>
-       server <%= member[:ciName] %> <%= member[:ciAttributes][:private_ip] %>:<%= internal_port %> check port <%= internal_port %> maxconn <%= node.haproxy.maxconn_server %> weight 1
+       server <%= member[:ciName] %> <%= member[:ciAttributes][:private_ip] %>:<%= internal_port %> check port <%= check_port %> maxconn <%= node.haproxy.maxconn_server %> weight 1
   <% end %>
   
 <% end %>


### PR DESCRIPTION
`check_port` in haproxy.cfg may be not always same as `internal_port`.
In case `check_port` should be same as `internal_port`, we could still
intentionally set `check_port` same as `internal_port` or leave
`check_port` blank (the logistics will assume `check_port` to be same
`internal_port`)