### PR TITLE
help etcd deploy /w primary & secondary clouds

### DIFF
--- a/components/cookbooks/etcd/recipes/configure.rb
+++ b/components/cookbooks/etcd/recipes/configure.rb
@@ -14,7 +14,9 @@ local_server_name = node.workorder.payLoad.ManagedVia[0]['ciName']
 # Get etcd members
 etcd_cluster = Array.new
 computes.each do |c, index|
-  etcd_cluster.push("#{c.ciName}=http://#{c.ciAttributes.private_ip}:2380")
+ if c.ciAttributes.has_key?("private_ip") && c.ciAttributes.private_ip != nil
+    etcd_cluster.push("#{c.ciName}=http://#{c.ciAttributes.private_ip}:2380")
+  end
 end
 
 


### PR DESCRIPTION
when deploying etcd on both primary & secondary clouds, it will fail
because the ip of secondary clouds will not be available when deploying
etcd on the primary clouds.

https://github.com/oneops/circuit-oneops-1/blob/master/components/cookbooks/etcd/recipes/configure.rb#L17

This small patch will make the deployment on primary & secondary clouds
barely finish and etcd works in primary clouds, but still not in
the most desirable state:

(1) this workaround only works for the first-time deployment and no
effects on replace
(2) the etcd on `secondary` clouds will dump warning logs to
`/var/log/message`, because the etcd config file on primary clouds
only include the peers from primary clouds, while the etcd config
file on secondary clouds include the peers from both primary AND
secondary clouds, which is confusing to etcd on secondary clouds,
but a working state to the  etcd in primary clouds.

A permanent primary & secondary deployment solution would need to answer
"what secondary clouds really mean to Etcd":

- a separate hot backup with real-time data replication from primary clouds?
- a separate cold standy with outdated info?
- a unified Etcd cluster including both primary and secondary nodes?

In worse case, this small patch may work as a sanity check to make sure
`private_ip` is not empty.