### PR TITLE
Get gslb host from gdns service instead of lb service for azure clouds

### DIFF
--- a/components/cookbooks/netscaler/recipes/get_gslb_connection.rb
+++ b/components/cookbooks/netscaler/recipes/get_gslb_connection.rb
@@ -12,7 +12,7 @@ if node.has_key?("ns_conn")
 end
 
 cloud_name = node[:workorder][:cloud][:ciName]
-if node[:workorder][:services].has_key?(:lb) && cloud_name !~ /azure/
+if node[:workorder][:services].has_key?(:lb) && node[:workorder][:cloud][:ciAttributes][:location] !~ /azure/
   cloud_service = node[:workorder][:services][:lb][cloud_name][:ciAttributes]
 else
   cloud_service = node[:workorder][:services][:gdns][cloud_name][:ciAttributes]

--- a/components/cookbooks/netscaler/recipes/get_gslb_connection.rb
+++ b/components/cookbooks/netscaler/recipes/get_gslb_connection.rb
@@ -12,7 +12,7 @@ if node.has_key?("ns_conn")
 end
 
 cloud_name = node[:workorder][:cloud][:ciName]
-if node[:workorder][:services].has_key?(:lb)
+if node[:workorder][:services].has_key?(:lb) && cloud_name !~ /azure/
   cloud_service = node[:workorder][:services][:lb][cloud_name][:ciAttributes]
 else
   cloud_service = node[:workorder][:services][:gdns][cloud_name][:ciAttributes]


### PR DESCRIPTION
Get gslb host from gdns service instead of lb service for azure clouds.