### PR TITLE
fix to skip security group if the deploy was made before including the nsg behavior

### DIFF
--- a/components/cookbooks/azure/libraries/network_interface_card.rb
+++ b/components/cookbooks/azure/libraries/network_interface_card.rb
@@ -161,7 +161,9 @@ module AzureNetwork
       #include the network securtiry group to the network interface
       nsg = AzureNetwork::NetworkSecurityGroup.new(creds, subscription)
       network_security_group = nsg.get(@rg_name, security_group_name)
-      network_interface.properties.network_security_group = network_security_group
+      if !security_group.nil?
+        network_interface.properties.network_security_group = network_security_group
+      end
 
       # create the nic
       nic = create_update(network_interface)

--- a/components/cookbooks/azure/libraries/network_security_group.rb
+++ b/components/cookbooks/azure/libraries/network_security_group.rb
@@ -17,7 +17,15 @@ module AzureNetwork
       result = response.body
       result
     rescue MsRestAzure::AzureOperationError => e
+    # If the error is that it doesn't exist, return nil
+    OOLog.info("Error of Exception is: '#{e.body.values[0]}'")
+    OOLog.info("Code of Exception is: '#{e.body.values[0]['code']}'")
+    if(e.body.values[0]['code'] == 'ResourceNotFound')
+      OOLog.info('SECGROUP DOES NOT EXIST!!  Returning nil')
+      return nil
+    else
       OOLog.fatal("AzureOperationError Exception trying to get network security group #{network_security_group_name} Response: #{e.body}")
+    end
     rescue Exception => e
       OOLog.fatal("Azure::Network Security group - Exception trying to get network security group #{network_security_group_name} from resource group: #{resource_group_name}\n\rAzure::Network Security group - Exception is: #{e.message}")
     end


### PR DESCRIPTION
fix to skip security group if the deploy was made before including the nsg behavior