### PR TITLE
Tomcat: update on minor version

### DIFF
--- a/components/cookbooks/tomcat/metadata.rb
+++ b/components/cookbooks/tomcat/metadata.rb
@@ -60,12 +60,11 @@ attribute 'version',
 attribute 'build_version',
           :description => "Build Version",
           :required => "required",
-          :default => "62",
+          :default => "70",
           :format => {
             :category => '1.Global',
-            :help => 'Tomcat minor version number.  Example: Version=7, Build Version=62 will install Tomcat 7.0.62',
-            :order => 5,
-            :form => {'field' => 'select', 'options_for_select' => [['42', '42'], ['62', '62']]}
+            :help => 'Tomcat minor version number. Example: Version=7, Build Version=70 will install Tomcat 7.0.70',
+            :order => 5
           }
 
 


### PR DESCRIPTION
Looks like all Tomcat mirrors only provide the download of the latest minor
version for each major version. Existing minor versions, e.g. 42, 62,
for tomcat 7 are no longer valid and their download links are void:

http://apache.claz.org/tomcat/tomcat-7/

http://apache.cs.utah.edu/tomcat/tomcat-7/

So it may be more flexible and less error-prone to have the minor version
field as text box than dropdown list, as new minor version keeps bumping up.