### PR TITLE
Etcd secondary cloud

### DIFF
--- a/components/cookbooks/etcd/libraries/etcd_util.rb
+++ b/components/cookbooks/etcd/libraries/etcd_util.rb
@@ -116,6 +116,24 @@ module Etcd
       puts "***FAULT:FATAL=#{msg}"
       Chef::Application.fatal!(msg)
     end
+    
+    def get_etcd_members_http(host)
+      uri = URI.parse("http://#{host}:2379/v2/members")
+      http = Net::HTTP.new(uri.host, uri.port)
+      req = Net::HTTP::Get.new(uri.path)
+      res = http.request(req)
+
+      if res.code != '200'
+        msg = "Failure getting etcd members. response code: #{res.code}, response body #{res.body}, response message #{res.message}"
+        Chef::Log.error(msg)
+        puts "***FAULT:FATAL= #{msg}"
+        e = Exception.new('no backtrace')
+        e.set_backtrace('')
+        raise e
+      end
+      
+      return res.body
+    end
 
   end
 

--- a/components/cookbooks/etcd/recipes/configure.rb
+++ b/components/cookbooks/etcd/recipes/configure.rb
@@ -5,24 +5,135 @@
 # Apache License, Version 2.0
 
 # Get all the required computes
+require 'uri'
+require 'net/http'
+
+# wire util library to chef resources.
+extend Etcd::Util
+Chef::Resource::RubyBlock.send(:include, Etcd::Util)
+
 if node.workorder.payLoad.has_key?(:computes)
-        computes = node.workorder.payLoad.computes
+  computes = node.workorder.payLoad.computes
 else
-        computes = node.workorder.payLoad.RequiresComputes
+  computes = node.workorder.payLoad.RequiresComputes
 end
 
 # Get the local compute
 local_server_ip = node.workorder.payLoad.ManagedVia[0]['ciAttributes']['private_ip']
 local_server_name = node.workorder.payLoad.ManagedVia[0]['ciName']
 
-# Get etcd members
-etcd_cluster = Array.new
-computes.each do |c, index|
- if c.ciAttributes.has_key?("private_ip") && c.ciAttributes.private_ip != nil
-    etcd_cluster.push("#{c.ciName}=http://#{c.ciAttributes.private_ip}:2380")
-  end
+primary_cloud = false
+
+if node.workorder.cloud.ciAttributes.has_key?("priority") &&
+    node.workorder.cloud.ciAttributes.priority == "1"
+  primary_cloud = true
 end
 
+Chef::Log.info("rfcAction: #{node.workorder.rfcCi.rfcAction}")
+
+etcd_cluster = Array.new
+# Get etcd members
+
+if primary_cloud == true
+    Chef::Log.info("In primary clouds")
+    #if node.workorder.rfcCi.rfcAction =~ /add/
+      computes.each do |c, index|
+        if c.ciAttributes.has_key?("private_ip") && c.ciAttributes.private_ip != nil
+          etcd_cluster.push("#{c.ciName}=http://#{c.ciAttributes.private_ip}:2380")
+        end
+      end
+      #else
+      #  Chef::Log.info("TODO: implement other rfcAction other than 'add'")
+      #end
+else
+# Assume that the nodes from secondary clouds will form a new Etcd cluster, which is
+# independet of the Etcd cluster in primary clouds.
+
+# The goal of the following method is to identify which IPs belong to secondary clouds.
+# It assumes that nodes in secondary clouds could access the primary Etcd by CURL.
+# For now, since FQDN always maps to the nodes in primary clouds and nodes do not
+# communicate with each other directly about who is from primary clouds, we could let
+# nodes in secondary clouds to take advantage of FQDN to ask who are the members of
+# primary Etcd cluster by a CURL.
+
+# For example:
+#
+# curl -L http://fqdn_url:2379/v2/members
+
+# The response is JSON object which contains the Etcd members in primary Etcd cluster:
+#
+# {"members":[{"id":"14ae5702cb4236f9","name":"compute-238213-2","peerURLs":
+# ["http://10.65.227.132:2380"],"clientURLs":["http://10.65.227.132:2379"]},
+# {"id":"656b212b423387e4","name":"compute-238213-1","peerURLs":["http://10.65.226.26:2380"],
+# "clientURLs":["http://10.65.226.26:2379"]}]}
+#
+# By removing the above returned IPs from workorder.PayLoad.computes, the remaining IPs should
+# belong to secondary clouds.
+
+# Note: there may be some assumptions for above apporach:
+# 1. Etcd component has to depend on "hostname" component with PTR enabled.
+# 2. Etcd in primary clouds is in working state
+# 3. all Etcd nodes in primary clouds are functioning correctly
+
+  # get FQDN by the dependency relationship from Etcd to FQDN
+  require 'json'
+  Chef::Log.info("secondary clouds...")
+  full_hostname = `host #{node[:ipaddress]} | awk '{ print $NF }' | sed 's/.$//'`.strip
+  Chef::Log.info("full_hostname: #{full_hostname}")
+  while true
+    if full_hostname =~ /NXDOMAIN/
+      Chef::Log.info("Unable to resolve instance-level FQDN from IP by PTR, sleep 5s and retry: #{node[:ipaddress]}")
+      sleep(5)
+      full_hostname = `host #{node[:ipaddress]} | awk '{ print $NF }' | sed 's/.$//'`.strip
+    else
+      break;
+    end
+  end
+  
+  # full_hostname from PTR is the cloud-level and instance-level FQDN
+  # but we need to use platform-level FQDN to connect to the Etcd running in primary clouds
+  # the temp solution is to:
+  # (1) drop the short hostname
+  # (2) drop cloud info (e.g. dfwiaas4) from cloud-level FQDN
+  # (3) add the platform name in front
+  arr = full_hostname.split(".")[1..-1]
+  arr.delete_at(3)
+  platform_name = node.workorder.box.ciName
+  # concat to get platform-level FQDN
+  platform_fqdn = [platform_name, arr.join(".")].join(".")
+  
+  Chef::Log.info("platform_fqdn: #{platform_fqdn}")
+  
+  json_members = get_etcd_members_http(platform_fqdn)
+  Chef::Log.info("json_members: "+JSON.parse(json_members).inspect.gsub("\n"," "))
+  
+  primary_hosts = Array.new
+  members = JSON.parse(json_members)["members"]
+  
+  # make sure the number of Etcd members returned from HTTP call is half of number of all computes
+  if members.length != (computes.length / 2)
+    msg = "Number of Etcd members #(members.length) returned from HTTP call is NOT half of number of all computes #{computes.length}."
+    Chef::Log.error(msg)
+    puts "***FAULT:FATAL= #{msg}"
+    e = Exception.new('no backtrace')
+    e.set_backtrace('')
+    raise e
+  end
+  
+  members.each do |m|
+    url = m["peerURLs"][0]
+    Chef::Log.info("member url is: #{url}")
+    host = URI.parse(url).host
+    primary_hosts.push(host)
+  end
+  
+  computes.each do |c, index|
+    if c.ciAttributes.has_key?("private_ip") && !primary_hosts.include?(c.ciAttributes.private_ip)
+      etcd_cluster.push("#{c.ciName}=http://#{c.ciAttributes.private_ip}:2380")
+    end
+  end
+  
+end
 
 if node.etcd.security_enabled == 'true'
   protocol = 'https'
@@ -73,11 +184,13 @@ member_flags = {
     'ETCD_CORS' => 'none'
 }.merge(JSON.parse(node.etcd.member_flags))
 
+etcd_initial_cluster_token = primary_cloud ? 'etcd-cluster-1' : 'etcd-cluster-2'
+
 cluster_flags = {
     'ETCD_INITIAL_ADVERTISE_PEER_URLS' => "http://#{local_server_ip}:2380",
     'ETCD_INITIAL_CLUSTER' => "#{etcd_cluster.join(",")}",
     'ETCD_INITIAL_CLUSTER_STATE' => 'new',
-    'ETCD_INITIAL_CLUSTER_TOKEN' => 'etcd-cluster-1',
+    'ETCD_INITIAL_CLUSTER_TOKEN' => etcd_initial_cluster_token,
     'ETCD_ADVERTISE_CLIENT_URLS' => "#{protocol}://#{local_server_ip}:2379"
 }.merge(JSON.parse(node.etcd.cluster_flags))
 


### PR DESCRIPTION
Assume that the nodes from secondary clouds will form a new Etcd
cluster, which is independent of the Etcd cluster in primary clouds.

The goal of the following method is to identify which IPs belong to
secondary clouds.
It assumes that nodes in secondary clouds could access the primary Etcd
by CURL.
For now, since FQDN always maps to the nodes in primary clouds and nodes
do not
communicate with each other directly about who is from primary clouds,
we could let
nodes in secondary clouds to take advantage of FQDN to ask who are the
members of
primary Etcd cluster by a CURL (http GET call).

For example:

curl -L http://fqdn_url:2379/v2/members

The response is JSON object which contains the Etcd members in primary
Etcd cluster:

{"members":[{"id":"14ae5702cb4236f9","name":"compute-238213-2","peerURLs":
["http://10.65.227.132:2380"],"clientURLs":["http://10.65.227.132:2379"]},
{"id":"656b212b423387e4","name":"compute-238213-1","peerURLs":["http://10.65.226.26:2380"],
"clientURLs":["http://10.65.226.26:2379"]}]}

By removing the above returned IPs from workorder.PayLoad.computes, the
remaining IPs should
belong to secondary clouds.

Note: there may be some assumptions for above approach:
1. Etcd component has to depend on "hostname" component with PTR
enabled.
2. Etcd in primary clouds is in working state
3. all Etcd nodes in primary clouds are functioning correctly

*Currently only rfcAction = add is supported, will plan to continue to work on other rfcAction*