### PR TITLE
postgres-governor: support seamless failover

### DIFF
--- a/components/cookbooks/postgresql-governor/metadata.rb
+++ b/components/cookbooks/postgresql-governor/metadata.rb
@@ -46,16 +46,26 @@ attribute 'postgresql_conf',
 
 
 attribute 'etcd_ttl',
-:description => "Etcd TTL (s)",
-:required => "required",
-:default => "30",
-:format => {
+  :description => "Etcd TTL (s)",
+  :required => "required",
+  :default => "30",
+  :format => {
     :help => 'TTL to acquire the leader lock. Think of it as the length of time before automatic failover process is initiated',
     :category => '3.Governor',
     :order => 1,
     :pattern => "[0-9\.]+"
 }
 
+attribute 'maximum_lag_on_failover',
+  :description => "Maximum Lag on xLog when failover",
+  :required => "required",
+  :default => "8388608",
+  :format => {
+    :help => 'The maximum lag on WAL between the Postgres master/leader and slave when the slave could still be considered as the candidate for Postgres master when the failover happens',
+    :category => '3.Governor',
+    :order => 2,
+    :pattern => "[0-9\.]+"
+}
 recipe "status", "Postgresql Status"
 recipe "start", "Start Postgresql"
 recipe "stop", "Stop Postgresql"

--- a/components/cookbooks/postgresql-governor/recipes/replace.rb
+++ b/components/cookbooks/postgresql-governor/recipes/replace.rb
@@ -1,2 +1,2 @@
-include_recipe "postgresql::add"
+include_recipe "postgresql-governor::add"
   

--- a/components/cookbooks/postgresql-governor/recipes/update.rb
+++ b/components/cookbooks/postgresql-governor/recipes/update.rb
@@ -1,2 +1,2 @@
-include_recipe "postgresql::add"
+include_recipe "postgresql-governor::add"
   

--- a/components/cookbooks/postgresql-governor/templates/default/postgres.yml.erb
+++ b/components/cookbooks/postgresql-governor/templates/default/postgres.yml.erb
@@ -14,7 +14,7 @@ postgresql:
   name: <%= node.workorder.payLoad.ManagedVia[0]['ciName'].split("-").join %>
   listen:  <%= node[:ipaddress] %>:5432
   data_dir: <%= node['postgresql-governor'][:data] %>
-  maximum_lag_on_failover: 1048576 # 1 megabyte in bytes
+  maximum_lag_on_failover: <%= node['postgresql-governor'][:maximum_lag_on_failover] %> # by default 8 megabyte in bytes
   # use_tcp_for_local_connection: true
   replication:
     username: replicator

--- a/packs/postgresql-governor.rb
+++ b/packs/postgresql-governor.rb
@@ -238,7 +238,7 @@ resource "hostname",
     :help => "optional hostname dns entry"
   },
   :attributes => {
-    :ptr_enabled => "false",
+    :ptr_enabled => "true",
     :ptr_source => "instance"
   }
 
@@ -289,6 +289,14 @@ end
     :to_resource   => 'hostname',
     :attributes    => { "propagate_to" => 'from', "flex" => false, "min" => 1, "max" => 1 }
 end
+
+#[ 'postgresql-governor' ].each do |from|
+#    relation "#{from}::depends_on::etcd",
+#    :relation_name => 'DependsOn',
+#    :from_resource => from,
+#    :to_resource   => 'etcd',
+#    :attributes    => { "flex" => false, "min" => 1, "max" => 1 }
+#end
 
 [ 'etcd' ].each do |from|
     relation "#{from}::depends_on::hostname",


### PR DESCRIPTION
This is the first version to support seamless failover
between primary and secondary clouds