### PR TITLE
Support VM & Etcd replacement for primary clouds

### DIFF
--- a/components/cookbooks/etcd/libraries/etcd_util.rb
+++ b/components/cookbooks/etcd/libraries/etcd_util.rb
@@ -117,24 +117,95 @@ module Etcd
       Chef::Application.fatal!(msg)
     end
     
-    def get_etcd_members_http(host)
-      uri = URI.parse("http://#{host}:2379/v2/members")
+    def get_etcd_members_http(host, port)
+      
+      uri = URI.parse("http://#{host}:#{port}/v2/members")
       http = Net::HTTP.new(uri.host, uri.port)
       req = Net::HTTP::Get.new(uri.path)
       res = http.request(req)
-
       if res.code != '200'
-        msg = "Failure getting etcd members. response code: #{res.code}, response body #{res.body}, response message #{res.message}"
-        Chef::Log.error(msg)
-        puts "***FAULT:FATAL= #{msg}"
-        e = Exception.new('no backtrace')
-        e.set_backtrace('')
-        raise e
+        exit_with_err("Failure getting etcd members. response code: #{res.code}, response body #{res.body}, response message #{res.message}")
       end
       
       return res.body
     end
+    
+    # Test if Etcd is running at some host by GET the list of members via http
+    #
+    # @param - host
+    # @param - port
+    
+    require 'socket'
+    require 'timeout'
 
+    def is_port_open?(ip, port)
+      begin
+        Timeout::timeout(1) do
+          begin
+            s = TCPSocket.new(ip, port)
+            s.close
+            return true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            return false
+          end
+        end
+      rescue Timeout::Error
+      end
+            
+      return false
+    end
+    
+    def get_full_hostname(ip)
+      full_hostname = `host #{ip} | awk '{ print $NF }' | sed 's/.$//'`.strip
+      while true
+        if full_hostname =~ /NXDOMAIN/
+          Chef::Log.info("Unable to resolve hostname from #{ip} by PTR, sleep and retry")
+          sleep(5)
+          full_hostname = `host #{ip} | awk '{ print $NF }' | sed 's/.$//'`.strip
+        else
+          break;
+        end
+      end
+      return full_hostname
+    end
+    
+    def get_cloud_fqdn(ip)
+      full_hostname = get_full_hostname(ip)
+      # full_hostname is the cloud-level and instance-level FQDN
+      # but we need to use cloud-level FQDN to connect to the Etcd running in (primary or secondary) clouds
+      # the temp solution is to:
+      # (1) drop the short hostname
+      # (2) add the platform name in front
+      arr = full_hostname.split(".")[1..-1]
+      platform_name = node.workorder.box.ciName
+      cloud_fqdn = [platform_name, arr.join(".")].join(".")
+      Chef::Log.info("cloud_fqdn: #{cloud_fqdn}")
+      return cloud_fqdn
+    end
+    
+    def depend_on_fqdn_ptr?
+      # if etcd depends on hostname/fqdn componenet with PTR enabled
+      depend_on_fqdn_ptr = false
+      node.workorder.payLoad[:DependsOn].each do |dep|
+        if dep["ciClassName"] =~ /Fqdn/
+          #Chef::Log.info("ciBaseAttributes content: "+dep["ciBaseAttributes"].inspect.gsub("\n"," "))
+          #Chef::Log.info("ciAttributes content: "+dep["ciAttributes"].inspect.gsub("\n"," "))
+          if !dep["ciBaseAttributes"].nil? && !dep["ciBaseAttributes"].empty?
+            hash = dep["ciBaseAttributes"]
+          else
+            hash = dep["ciAttributes"]
+          end
+
+          if hash["ptr_enabled"] == "true"
+            depend_on_fqdn_ptr = true
+            Chef::Log.info("depend_on_fqdn_ptr")
+            break
+          end
+        end
+      end
+      return depend_on_fqdn_ptr
+    end
+  
   end
 
 end

--- a/components/cookbooks/etcd/recipes/add.rb
+++ b/components/cookbooks/etcd/recipes/add.rb
@@ -97,7 +97,8 @@ ruby_block 'setting etcd member id' do
     if node.etcd.security_enabled == 'true'
       command = "etcdctl --ca-file #{node.etcd.security_path}/ca.crt --cert-file #{node.etcd.security_path}/server.crt --key-file #{node.etcd.security_path}/server.key member list | grep $(hostname -i)"
     elsif node.etcd.security_enabled == 'false'
-      command = 'etcdctl member list | grep $(hostname -i)'
+      cname = node.workorder.payLoad.ManagedVia[0]['ciName']
+      command = "etcdctl member list | grep #{cname}"
     end
 
     while retry_count < 10

--- a/components/cookbooks/etcd/recipes/delete.rb
+++ b/components/cookbooks/etcd/recipes/delete.rb
@@ -7,23 +7,49 @@
 require 'net/http'
 require 'uri'
 
-# Removing etcd member
-member_id=node.workorder.rfcCi['ciAttributes']['member_id']
-uri = URI.parse("http://localhost:2379/v2/members/#{member_id}")
-http = Net::HTTP.new(uri.host, uri.port)
-req = Net::HTTP::Delete.new(uri.path)
-res = http.request(req)
+extend Etcd::Util
+Chef::Resource::RubyBlock.send(:include, Etcd::Util)
 
-if res.code != '204'
-  msg = "Failure deleting etcd member #{member_id}. response code: #{res.code}, response body #{res.body}, response message #{res.message}"
-  Chef::Log.error(msg)
-  puts "***FAULT:FATAL= #{msg}"
-  e = Exception.new('no backtrace')
-  e.set_backtrace('')
-  raise e
-else
-  msg = "Success deleting etcd member #{member_id}. response code: #{res.code}, response body #{res.body}, response message #{res.message}"
-  Chef::Log.info(msg)
+# Removing etcd member
+member_id = node.workorder.rfcCi['ciAttributes']['member_id']
+
+etcd_conn = "localhost"
+etcd_conn = get_cloud_fqdn(node[:ipaddress]) if depend_on_fqdn_ptr?
+
+# if VM is replaced, `member_id` will be empty, so another way
+# to retrieve member_id is to query the etcd cluster
+if member_id.nil? || member_id.empty?
+  json_members = get_etcd_members_http(etcd_conn, 2379)
+  Chef::Log.info("json_members: "+JSON.parse(json_members).inspect.gsub("\n"," "))
+
+  members = JSON.parse(json_members)["members"]
+  members.each do |m|
+    if node.workorder.payLoad.ManagedVia[0]['ciName'] == m["name"]
+      member_id = m["id"]
+      break
+    end
+  end
+  Chef::Log.info("get member_id: #{member_id} from querying Etcd cluster")
+end
+
+# only delete the member if member_id is not empty
+unless member_id.nil? || member_id.empty?
+  uri = URI.parse("http://#{etcd_conn}:2379/v2/members/#{member_id}")
+  http = Net::HTTP.new(uri.host, uri.port)
+  req = Net::HTTP::Delete.new(uri.path)
+  res = http.request(req)
+
+  if res.code != '204'
+    msg = "Failure deleting etcd member #{member_id}. response code: #{res.code}, response body #{res.body}, response message #{res.message}"
+    Chef::Log.error(msg)
+    puts "***FAULT:FATAL= #{msg}"
+    e = Exception.new('no backtrace')
+    e.set_backtrace('')
+    raise e
+  else
+    msg = "Success deleting etcd member #{member_id}. response code: #{res.code}, response body #{res.body}, response message #{res.message}"
+    Chef::Log.info(msg)
+  end
 end
 
 # stop etcd service.

--- a/components/cookbooks/etcd/recipes/register_new_node.rb
+++ b/components/cookbooks/etcd/recipes/register_new_node.rb
@@ -1,0 +1,34 @@
+
+require 'net/http'
+require 'uri'
+
+extend Etcd::Util
+Chef::Resource::RubyBlock.send(:include, Etcd::Util)
+
+# https://coreos.com/etcd/docs/latest/runtime-configuration.html#add-a-new-member
+# need to add the member to the cluster first
+
+etcd_conn = "localhost"
+etcd_conn = get_cloud_fqdn(node[:ipaddress]) if depend_on_fqdn_ptr?
+
+full_hostname = get_full_hostname(node[:ipaddress])
+peerURLs = "http://#{full_hostname}:2380"
+
+uri = URI.parse("http://#{etcd_conn}:2379/v2/members")
+req = Net::HTTP::Post.new(uri.path, initheader = {'Content-Type' =>'application/json'})
+req.body = "{\"peerURLs\":[\"#{peerURLs}\"]}"
+http = Net::HTTP.new(uri.host, uri.port)
+
+res = http.request(req)
+
+if res.code != '201'
+    msg = "Failure registering etcd member #{node[:ipaddress]}. response code: #{res.code}, response body #{res.body}, response message #{res.message}"
+    Chef::Log.error(msg)
+    puts "***FAULT:FATAL= #{msg}"
+    e = Exception.new('no backtrace')
+    e.set_backtrace('')
+    raise e
+    else
+    msg = "Success registering etcd member #{node[:ipaddress]}. response code: #{res.code}, response body #{res.body}, response message #{res.message}"
+    Chef::Log.info(msg)
+end

--- a/components/cookbooks/etcd/recipes/replace.rb
+++ b/components/cookbooks/etcd/recipes/replace.rb
@@ -4,5 +4,7 @@
 # Author : OneOps
 # Apache License, Version 2.0
 
+
 include_recipe 'etcd::delete'
+include_recipe 'etcd::register_new_node'
 include_recipe 'etcd::add'

--- a/components/cookbooks/etcd/recipes/update.rb
+++ b/components/cookbooks/etcd/recipes/update.rb
@@ -4,5 +4,5 @@
 # Author : OneOps
 # Apache License, Version 2.0
 
-include_recipe 'etcd::delete'
+#include_recipe 'etcd::delete'
 include_recipe 'etcd::add'


### PR DESCRIPTION
Existing replace.rb may not work when VM is replaced, because it
deletes the member but not register the new node into the existing
cluster, as mentioned:

https://coreos.com/etcd/docs/latest/runtime-configuration.html#add-a-new-member

This patch will run VM and Etcd replacement smoothly with the following
assumptions:

(1) Etcd needs to depend on hostname component
(2) hostname component needs to enable PTR record

Plus, upon VM replacement the IP address will change, which will
negatively affect other Etcd nodes if using IP in Etcd config.
When Etcd depends on hostname with PTR enabled, use instance-level hostname
(consistent and unchanged upon VM replacement), instead of IP address,
in the Etcd config files.

Finally, to differentiate from `replace.rb`, I assume `update.rb`is simply used to update the Etcd config or executable whiling keeping the existing membership with the cluster, so removing `etcd:delete`