### PR TITLE
Governor PG & Etcd: support VM replace & update

### DIFF
--- a/components/cookbooks/etcd/recipes/configure.rb
+++ b/components/cookbooks/etcd/recipes/configure.rb
@@ -12,6 +12,8 @@ require 'net/http'
 extend Etcd::Util
 Chef::Resource::RubyBlock.send(:include, Etcd::Util)
 
+platform_level_fqdn = true
+
 if node.workorder.payLoad.has_key?(:computes)
   computes = node.workorder.payLoad.computes
 else
@@ -19,8 +21,8 @@ else
 end
 
 local_server_ip =  node.workorder.payLoad.ManagedVia[0]['ciAttributes']['private_ip']
-# `local_server_ip` is updated with the full hostname only if `etcd` depends on hostname component with PTR enabled
-local_server_ip =  get_full_hostname(local_server_ip) if depend_on_fqdn_ptr?
+# `local_server_ip` is updated with the full hostname only if `etcd` depends on hostname component
+local_server_ip =  get_full_hostname(node[:ipaddress]) if depend_on_hostname_ptr?
 local_server_name = node.workorder.payLoad.ManagedVia[0]['ciName']
 
 primary_cloud = false
@@ -36,115 +38,58 @@ etcd_cluster = Array.new
 # Get etcd members
 
 if primary_cloud == true
-    Chef::Log.info("In primary clouds")
-    #if node.workorder.rfcCi.rfcAction =~ /add/
+  Chef::Log.info("In primary clouds")
+  if depend_on_hostname_ptr?
+    platform_fqdn = get_fqdn(node[:ipaddress], platform_level_fqdn)
+    # query platform-level fqdn for the computes in primary clouds
+    primary_computes_ips = `host #{platform_fqdn} | awk '{ print $NF }'`.split("\n")
+    # if there are computes from secondary clouds
+    if primary_computes_ips.length < computes.length
+      primary_computes = Array.new
+      # filter out the compute instances in secondary clouds from `computes`
       computes.each do |c, index|
-        if c.ciAttributes.has_key?("private_ip") && c.ciAttributes.private_ip != nil
-          if depend_on_fqdn_ptr?
-            hostname = get_full_hostname(c.ciAttributes.private_ip)
-            etcd_cluster.push("#{c.ciName}=http://#{hostname}:2380")
-          else
-            etcd_cluster.push("#{c.ciName}=http://#{c.ciAttributes.private_ip}:2380")
-          end
-  
+        if c.ciAttributes.has_key?("private_ip") && c.ciAttributes.private_ip != nil &&
+            primary_computes_ips.include?(c.ciAttributes.private_ip)
+          primary_computes.push(c)
         end
       end
-      #else
-      #  Chef::Log.info("TODO: implement other rfcAction other than 'add'")
-      #end
+      computes = primary_computes
+    end
+  end
+
+  computes.each do |c, index|
+    if c.ciAttributes.has_key?("private_ip") && c.ciAttributes.private_ip != nil
+      if depend_on_hostname_ptr?
+        full_hostname = get_full_hostname(c.ciAttributes.private_ip)
+        etcd_cluster.push("#{c.ciName}=http://#{full_hostname}:2380")
+      else
+        etcd_cluster.push("#{c.ciName}=http://#{c.ciAttributes.private_ip}:2380")
+      end
+    end
+  end
 else
+
 # Assume that the nodes from secondary clouds will form a new Etcd cluster, which is
 # independet of the Etcd cluster in primary clouds.
 
 # The goal of the following method is to identify which IPs belong to secondary clouds.
-# It assumes that nodes in secondary clouds could access the primary Etcd by CURL.
-# For now, since FQDN always maps to the nodes in primary clouds and nodes do not
-# communicate with each other directly about who is from primary clouds, we could let
-# nodes in secondary clouds to take advantage of FQDN to ask who are the members of
-# primary Etcd cluster by a CURL.
+# It assumes:
+# (1) Etcd component has to depend on "hostname" component with PTR enabled.
+# (2) no LB is used. Otherwise, querying FQDN (host `fqnd`) will return the IPs of LB
 
-# For example:
-#
-# curl -L http://fqdn_url:2379/v2/members
-
-# The response is JSON object which contains the Etcd members in primary Etcd cluster:
-#
-# {"members":[{"id":"14ae5702cb4236f9","name":"compute-238213-2","peerURLs":
-# ["http://10.65.227.132:2380"],"clientURLs":["http://10.65.227.132:2379"]},
-# {"id":"656b212b423387e4","name":"compute-238213-1","peerURLs":["http://10.65.226.26:2380"],
-# "clientURLs":["http://10.65.226.26:2379"]}]}
-#
-# By removing the above returned IPs from workorder.PayLoad.computes, the remaining IPs should
+# By querying the platform-level fqdn, we could know the computes from the primary clouds.
+# After removing the returned IPs from workorder.PayLoad.computes, the remaining IPs should
 # belong to secondary clouds.
 
-# Note: there may be some assumptions for above apporach:
-# 1. Etcd component has to depend on "hostname" component with PTR enabled.
-# 2. Etcd in primary clouds is in working state
-# 3. all Etcd nodes in primary clouds are functioning correctly
-
-  # get FQDN by the dependency relationship from Etcd to FQDN
-  require 'json'
   Chef::Log.info("secondary clouds...")
-  full_hostname = `host #{node[:ipaddress]} | awk '{ print $NF }' | sed 's/.$//'`.strip
-  Chef::Log.info("full_hostname: #{full_hostname}")
-  while true
-    if full_hostname =~ /NXDOMAIN/
-      Chef::Log.info("Unable to resolve instance-level FQDN from IP by PTR, sleep 5s and retry: #{node[:ipaddress]}")
-      sleep(5)
-      full_hostname = `host #{node[:ipaddress]} | awk '{ print $NF }' | sed 's/.$//'`.strip
-    else
-      break;
-    end
-  end
-  
-  # full_hostname from PTR is the cloud-level and instance-level FQDN
-  # but we need to use platform-level FQDN to connect to the Etcd running in primary clouds
-  # the temp solution is to:
-  # (1) drop the short hostname
-  # (2) drop cloud info (e.g. dfwiaas4) from cloud-level FQDN
-  # (3) add the platform name in front
-  arr = full_hostname.split(".")[1..-1]
-  arr.delete_at(3)
-  platform_name = node.workorder.box.ciName
-  # concat to get platform-level FQDN
-  platform_fqdn = [platform_name, arr.join(".")].join(".")
-  
-  Chef::Log.info("platform_fqdn: #{platform_fqdn}")
-  
-  json_members = get_etcd_members_http(platform_fqdn, 2379)
-  Chef::Log.info("json_members: "+JSON.parse(json_members).inspect.gsub("\n"," "))
-  
-  primary_hosts = Array.new
-  members = JSON.parse(json_members)["members"]
-  
-  # make sure the number of Etcd members returned from HTTP call is half of number of all computes
-  if members.length != (computes.length / 2)
-    msg = "Number of Etcd members #(members.length) returned from HTTP call is NOT half of number of all computes #{computes.length}."
-    Chef::Log.error(msg)
-    puts "***FAULT:FATAL= #{msg}"
-    e = Exception.new('no backtrace')
-    e.set_backtrace('')
-    raise e
-  end
-  
-  members.each do |m|
-    url = m["peerURLs"][0]
-    Chef::Log.info("member url is: #{url}")
-    host = URI.parse(url).host
-    require 'resolv'
-    unless host =~ Resolv::IPv4::Regex
-      # ip is short hostname, convert it to ip address
-      host = `host #{host} | awk '{ print $NF }'`.strip
-    end
-    
-    primary_hosts.push(host)
-  end
-  
-  Chef::Log.info("primary_hosts: #{primary_hosts.to_s}")
+  platform_fqdn = get_fqdn(node[:ipaddress], platform_level_fqdn)
+  primary_computes_ips = `host #{platform_fqdn} | awk '{ print $NF }'`.split("\n")
+  Chef::Log.info("primary_computes_ips: #{primary_computes_ips.to_s}")
   
   computes.each do |c, index|
-    if c.ciAttributes.has_key?("private_ip") && !primary_hosts.include?(c.ciAttributes.private_ip)
-      if depend_on_fqdn_ptr?
+    if c.ciAttributes.has_key?("private_ip") && !primary_computes_ips.include?(c.ciAttributes.private_ip)
+      Chef::Log.info("c.ciAttributes.private_ip: #{c.ciAttributes.private_ip}")
+      if depend_on_hostname_ptr?
         hostname = get_full_hostname(c.ciAttributes.private_ip)
         etcd_cluster.push("#{c.ciName}=http://#{hostname}:2380")
       else
@@ -154,6 +99,7 @@ else
   end
   
 end
+
 
 if node.etcd.security_enabled == 'true'
   protocol = 'https'
@@ -209,7 +155,14 @@ etcd_initial_cluster_token = primary_cloud ? 'etcd-cluster-1' : 'etcd-cluster-2'
 etcd_initial_cluster_state = "new"
 if node.workorder.rfcCi.rfcAction == "replace"
   etcd_initial_cluster_state = "existing"
+elsif node.workorder.rfcCi.rfcAction == "update"
+  # continue to use the original state
+  etcd_initial_cluster_state = `cat /etc/etcd/etcd.conf | grep ETCD_INITIAL_CLUSTER_STATE | tr "=" "\n" | tail -n 1 | tr -d '"'`.strip
+  if etcd_initial_cluster_state.empty?
+     etcd_initial_cluster_state = "new"
+  end
 end
+
 cluster_flags = {
     'ETCD_INITIAL_ADVERTISE_PEER_URLS' => "http://#{local_server_ip}:2380",
     'ETCD_INITIAL_CLUSTER' => "#{etcd_cluster.join(",")}",

--- a/components/cookbooks/etcd/recipes/delete.rb
+++ b/components/cookbooks/etcd/recipes/delete.rb
@@ -13,8 +13,10 @@ Chef::Resource::RubyBlock.send(:include, Etcd::Util)
 # Removing etcd member
 member_id = node.workorder.rfcCi['ciAttributes']['member_id']
 
+platform_level_fqdn = false
 etcd_conn = "localhost"
-etcd_conn = get_cloud_fqdn(node[:ipaddress]) if depend_on_fqdn_ptr?
+# need to get cloud-level fqdn
+etcd_conn = get_fqdn(node[:ipaddress], platform_level_fqdn) if depend_on_hostname_ptr?
 
 # if VM is replaced, `member_id` will be empty, so another way
 # to retrieve member_id is to query the etcd cluster
@@ -29,7 +31,7 @@ if member_id.nil? || member_id.empty?
       break
     end
   end
-  Chef::Log.info("get member_id: #{member_id} from querying Etcd cluster")
+  Chef::Log.info("d: #{member_id} from querying Etcd cluster")
 end
 
 # only delete the member if member_id is not empty

--- a/components/cookbooks/etcd/recipes/register_new_node.rb
+++ b/components/cookbooks/etcd/recipes/register_new_node.rb
@@ -8,9 +8,14 @@ Chef::Resource::RubyBlock.send(:include, Etcd::Util)
 # https://coreos.com/etcd/docs/latest/runtime-configuration.html#add-a-new-member
 # need to add the member to the cluster first
 
+platform_level_fqdn = false
 etcd_conn = "localhost"
-etcd_conn = get_cloud_fqdn(node[:ipaddress]) if depend_on_fqdn_ptr?
 
+# need to get cloud-level fqdn which will be used as the URL to connect to
+# etcd in the primary or secondary cloud
+etcd_conn = get_fqdn(node[:ipaddress], platform_level_fqdn) if depend_on_hostname_ptr?
+
+# no diff to use use platform-level or cloud-level hostname
 full_hostname = get_full_hostname(node[:ipaddress])
 peerURLs = "http://#{full_hostname}:2380"
 

--- a/components/cookbooks/postgresql-governor/recipes/add.rb
+++ b/components/cookbooks/postgresql-governor/recipes/add.rb
@@ -85,18 +85,6 @@ else
   # just want to set some value for key `/service/postgres/initialize` to avoid unclean leader takeover
   # the value of `/service/postgres/initialize/` is not important
   client.set('/service/postgres/initialize', value: ciName)
-  
-  fqdn_resolv = `host #{node[:platform_fqdn]} | awk '{ print $NF }'`.split("\n")
-  Chef::Log.info("fqdn_resolv: #{fqdn_resolv.to_s}")
-  while true
-    if fqdn_resolv.length > 1
-      Chef::Log.info("platform FQDN are resolved into more than 1 IPs.")
-      sleep(5)
-      fqdn_resolv = `host #{node[:platform_fqdn]} | awk '{ print $NF }'`.split("\n")
-    else
-      break;
-    end
-  end
 
 end
 


### PR DESCRIPTION
Etcd: support VM replace and Etcd update on primary and secondary
clouds, so that bad VM could be replaced. Note: for Etcd, if there are n
nodes in primary clouds, the maximum number of VM could be replaced at
one shot is n/2 (if n is an odd) or n/2-1 (if n is an even). This is
because if the number of replacement is larger than that, it will make
the Etcd cluster unavailable (loss of quorum) so that `delete.rb` (a
part of Etcd `replace.rb`) will fail.

In general, Etcd secondary cloud and replacement support is based on:

(1) Etcd has to depend on hostname (which is reasonable because IP
address could be changed upon VM replacement and using IP address in
Etcd config may not be highly encouraged)

(2) No LB is in the deployment plan. Because we propose to use the
method of querying platform-level fqdn (host `fqdn`) to figure out which
compute is from primary clouds. If using LB, the result of querying fqdn
will be the IP of LB, rather the IP of computes.

Governor PG: Based on the assumption of Etcd depending on hostname and
no LB is involved, the postgresql-governor pack file got updated here.

Tested on primary and secondary cloud setup with query examples.