### PR TITLE
Couchbase: use private_ip & proper component name for dependency lookup

### DIFF
--- a/components/cookbooks/cb_cluster/recipes/base.rb
+++ b/components/cookbooks/cb_cluster/recipes/base.rb
@@ -24,7 +24,7 @@ else
   # dynamic payload defined in the pack to get the resources
   dependencies = node.workorder.payLoad.cm
   dependencies.each do |depends_on|
-    class_name = depends_on["ciClassName"].downcase.gsub("bom\.","")
+    class_name = depends_on["ciClassName"].downcase.gsub("bom\.oneops\.1\.","")
     Chef::Log.info("class_name:#{class_name}")
     if class_name == "couchbase"
       if depends_on["ciAttributes"].has_key?("adminuser")

--- a/components/cookbooks/couchbase/libraries/cluster.rb
+++ b/components/cookbooks/couchbase/libraries/cluster.rb
@@ -15,7 +15,11 @@ class Chef::Recipe::Cluster
     end
     
     @this_node.workorder.payLoad.cb_cmp.each do |n|
-      ip_address = n["ciAttributes"]["private_ip"]
+      if node['ciAttributes'].has_key?("public_ip") && !node['ciAttributes']['public_ip'].empty?
+	ip_address=node['ciAttributes']["public_ip"]
+      else
+        ip_address=node['ciAttributes']["private_ip"]
+      end
       action = n[:rfcAction] == 'delete' ? 'delete' : 'nothing'
       @ips.push(Chef::Recipe::Node.new(ip_address, action))
     end

--- a/components/cookbooks/couchbase/libraries/component/couchbase_component.rb
+++ b/components/cookbooks/couchbase/libraries/component/couchbase_component.rb
@@ -65,7 +65,7 @@ module Couchbase
             def remove_from_cluster
 
                 @cluster = Couchbase::CouchbaseCluster.new(@ip, @username, @password)
-                outgoing_node_ip = @data.workorder.payLoad.ManagedVia.first.ciAttributes.public_ip
+                outgoing_node_ip = @data.workorder.payLoad.ManagedVia.first.ciAttributes.private_ip
                 servers = []
                 begin
                   servers = @cluster.list_servers
@@ -107,11 +107,11 @@ module Couchbase
                   return
                 end
                                   
-                incoming_node_ip = @data.workorder.payLoad.ManagedVia.first.ciAttributes.public_ip
+                incoming_node_ip = @data.workorder.payLoad.ManagedVia.first.ciAttributes.private_ip
 
                 # use Ip of different server in cluster
                 @data.workorder.payLoad.cb_cmp.each do |n|
-                  ip=n['ciAttributes']['public_ip']
+                  ip=n['ciAttributes']['private_ip']
                   if (ip != incoming_node_ip)
                     begin
                       @cluster = Couchbase::CouchbaseCluster.new(ip, @username, @password)

--- a/components/cookbooks/couchbase/libraries/component/diagnostic_cache_component.rb
+++ b/components/cookbooks/couchbase/libraries/component/diagnostic_cache_component.rb
@@ -7,7 +7,7 @@ module Couchbase
 
         # dc is dynamic payload defined in the pack to get the resources
         if (@data.workorder.payLoad.has_key?('dc'))
-          dc = @data.workorder.payLoad.dc.select { |c| c['ciClassName'] == 'Couchbase' }.first
+          dc = @data.workorder.payLoad.dc.select { |c| c['ciClassName'].split('.').last == 'Couchbase' }.first
   
           attributes = dc["ciAttributes"]
           @username = attributes["adminuser"]
@@ -27,8 +27,8 @@ module Couchbase
         end
         
         @nodes.each { |node|
-          if node['ciAttributes'].has_key?("public_ip")
-            ip=node['ciAttributes']["public_ip"]
+          if node['ciAttributes'].has_key?("private_ip")
+            ip=node['ciAttributes']["private_ip"]
             begin
               @cluster = Couchbase::CouchbaseCluster.new(ip, @username, @password)
               if @cluster.list_nodes.length > 0

--- a/components/cookbooks/couchbase/libraries/component/ring_component.rb
+++ b/components/cookbooks/couchbase/libraries/component/ring_component.rb
@@ -24,14 +24,19 @@ module Couchbase
                 first_couchbase_node = @data["workorder"]["payLoad"]["DependsOn"][0]
 
                 compute_nodes.each do |node|
-                    if node["rfcAction"] != "add"
+                  if node["rfcAction"] != "add"
+                    if node['ciAttributes'].has_key?("public_ip") && !node['ciAttributes']['public_ip'].empty?
+	              ip_address=node['ciAttributes']["public_ip"]
+		    else
+		      ip_address=node['ciAttributes']["private_ip"]
+		    end
 
-                        return {
-                            "ip" => node["ciAttributes"]["private_ip"],
+                    return {
+                            "ip" => ip_address,
                             "adminuser" => first_couchbase_node["ciAttributes"]["adminuser"],
                             "adminpassword" => first_couchbase_node["ciAttributes"]["adminpassword"]
                         }
-                    end
+                  end
 
                 end
                 # must be creating cluster or updating it

--- a/components/cookbooks/couchbase/libraries/couchbase_cluster.rb
+++ b/components/cookbooks/couchbase/libraries/couchbase_cluster.rb
@@ -13,7 +13,6 @@ module Couchbase
       @password = password
       @cli=Couchbase::CouchbaseCLI.new(ip, user, password)
       @rest=Couchbase::CouchbaseREST.new(ip, user, password)
-
       begin
         list_buckets
       rescue Exception => e

--- a/components/cookbooks/couchbase/recipes/nodes.rb
+++ b/components/cookbooks/couchbase/recipes/nodes.rb
@@ -14,7 +14,7 @@
 def get_node_ips
   ips = []
   node.workorder.payLoad.ManagedVia.each do |n|
-    ips.push(n[:ciAttributes]['public_ip'])
+    ips.push(n[:ciAttributes]['priviate_ip'])
   end
   ips
 end
@@ -24,7 +24,7 @@ end
 ##
 def get_couchbase_attributes
   array = node.workorder.payLoad.DependsOn.reject do |d|
-    d['ciClassName'] != 'Couchbase'
+    d['ciClassName'].split('.').last != 'Couchbase'
   end
   array.first[:ciAttributes]
 end
@@ -36,7 +36,7 @@ def get_cluster
   array = node.workorder.payLoad.ManagedVia.reject do |d|
     d['isActiveInRelease']
   end
-  array.first[:ciAttributes]['public_ip']
+  array.first[:ciAttributes]['private_ip']
 end
 
 cluster = get_cluster

--- a/packs/couchbase.rb
+++ b/packs/couchbase.rb
@@ -9,9 +9,9 @@ platform :attributes => {'autoreplace' => 'false'}
 
 # Overriding the default compute
 resource 'compute',
-         :attributes => {
-           'ostype' => 'default-cloud',
-           'size' => 'S'
+         :cookbook => 'oneops.1.compute',
+         :attributes => {'ostype' => 'default-cloud',
+                         'size' => 'S'
          }
 
 resource 'user-app',
@@ -49,7 +49,7 @@ resource 'couchbase',
                 "returnRelation": false, 
                 "relationName": "bom.DependsOn", 
                 "direction": "to", 
-                "targetClassName": "bom.oneops.1.Ring", 
+                "targetClassName": "bom.oneops.1.Ring",
                 "relations": [ 
                   { "returnObject": false, 
                     "returnRelation": false, 
@@ -90,13 +90,13 @@ resource 'bucket',
                  "returnRelation": false, 
                  "relationName": "bom.DependsOn", 
                  "direction": "from", 
-                 "targetClassName": "bom.oneops.1.Ring", 
+                 "targetClassName": "bom.oneops.1.Ring",
                  "relations": [ 
                    { "returnObject": true, 
                      "returnRelation": false, 
                      "relationName": "bom.DependsOn", 
                      "direction": "from",
-                     "targetClassName": "bom.oneops.1.Couchbase" 
+                     "targetClassName": "bom.oneops.1.Couchbase"
                      
                    } 
                   ] 
@@ -182,7 +182,6 @@ resource "secgroup",
 [{:from => 'user-app',  :to => 'compute'},
  {:from => 'couchbase', :to => 'user-app'},
  {:from => 'couchbase', :to => 'compute'},
- {:from => 'couchbase', :to => 'os'},
  {:from => 'couchbase', :to => 'volume'},
  {:from => 'build', :to => 'couchbase'}].each do |link|
   relation "#{link[:from]}::depends_on::#{link[:to]}",
@@ -228,7 +227,7 @@ relation "bucket::depends_on::couchbase",
          :attributes    =>{"flex" => false}
 
 # managed_via
-['user-app','couchbase','bucket','couchbase-cluster','build'].each do |from|
+['user-app', 'couchbase', 'bucket', 'couchbase-cluster', 'build'].each do |from|
   relation "#{from}::managed_via::compute",
            :except => ['_default'],
            :relation_name => 'ManagedVia',


### PR DESCRIPTION
(1) it looks like in most cases, `ci.attributes.public_ip` is empty,
leading to failure at multiple places. So have to use `private_ip` as a
workaround until figuring out why `ci.attributes.public_ip` is empty.

(2) the old coding uses `bom.Couchbase` for detecting the dependency.
However the components from `circuit-oneops-1` are always referred as
`bom.oneops.1.xxx`, where xxx could be `compute`, `ring` and
`Couchbase`. This PR will make sure the right component name are
correctly referred in couchbase pack.

Tested in both `single` and `redundant` environments.