### PR TITLE
ElasticSearch and Kibana improvements

### DIFF
--- a/components/cookbooks/es/attributes/default.rb
+++ b/components/cookbooks/es/attributes/default.rb
@@ -43,7 +43,7 @@ default.elasticsearch[:pid_file]  = "#{node.elasticsearch[:pid_path]}/#{node.ela
 # Maximum amount of memory to use is automatically computed as one half of total available memory on the machine.
 # You may choose to set it in your node/role configuration instead.
 #
-allocated_memory = "#{(node.memory.total.to_i * 0.5 ).floor / 1024}m"
+allocated_memory = "#{(node.memory.total.to_i * 0.6 ).floor / 1024}m"
 default.elasticsearch[:allocated_memory] = allocated_memory
 
 # === GARBAGE COLLECTION SETTINGS

--- a/components/cookbooks/es/attributes/default.rb
+++ b/components/cookbooks/es/attributes/default.rb
@@ -15,7 +15,7 @@ node.normal[:elasticsearch]    = DeepMerge.merge(node.normal[:elasticsearch].to_
 
 # === VERSION AND LOCATION
 #
-default.elasticsearch[:version]       = "1.1.1"
+default.elasticsearch[:version]       = "1.7.1"
 default.elasticsearch[:host]          = "https://download.elastic.co"
 default.elasticsearch[:repository]    = "/elasticsearch/"
 default.elasticsearch[:filename]      = "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
@@ -43,7 +43,7 @@ default.elasticsearch[:pid_file]  = "#{node.elasticsearch[:pid_path]}/#{node.ela
 # Maximum amount of memory to use is automatically computed as one half of total available memory on the machine.
 # You may choose to set it in your node/role configuration instead.
 #
-allocated_memory = "#{(node.memory.total.to_i * 0.6 ).floor / 1024}m"
+allocated_memory = "#{(node.memory.total.to_i * 0.5 ).floor / 1024}m"
 default.elasticsearch[:allocated_memory] = allocated_memory
 
 # === GARBAGE COLLECTION SETTINGS

--- a/components/cookbooks/es/metadata.rb
+++ b/components/cookbooks/es/metadata.rb
@@ -24,7 +24,7 @@ attribute 'mirrors',
 attribute 'version',
           :description => 'Version',
           :required => 'required',
-          :default => '2.3.2',
+          :default => '1.7.1',
           :format => {
               :important => true,
               :help => 'Version of ElasticSearch',

--- a/components/cookbooks/es/metadata.rb
+++ b/components/cookbooks/es/metadata.rb
@@ -24,14 +24,13 @@ attribute 'mirrors',
 attribute 'version',
           :description => 'Version',
           :required => 'required',
-          :default => '1.1.1',
+          :default => '2.3.2',
           :format => {
               :important => true,
               :help => 'Version of ElasticSearch',
               :category => '2.Global',
               :order => 1,
-              :form => {'field' => 'select', 'options_for_select' => [['1.1.1', '1.1.1'],['1.3.2', '1.3.2'],['1.4.1', '1.4.1'],['1.4.4', '1.4.4'],['1.5.0', '1.5.0'],['1.5.1', '1.5.1'],['1.7.1', '1.7.1'],
-                ['2.0.0', '2.0.0']]}
+              :form => {'field' => 'select', 'options_for_select' => [['1.1.1', '1.1.1'],['1.3.2', '1.3.2'],['1.4.1', '1.4.1'],['1.4.4', '1.4.4'],['1.5.0', '1.5.0'],['1.5.1', '1.5.1'],['1.7.1', '1.7.1'],['2.0.0', '2.0.0']]}
           }
 
 attribute 'cluster_name',

--- a/components/cookbooks/es/recipes/wire_ci_attr.rb
+++ b/components/cookbooks/es/recipes/wire_ci_attr.rb
@@ -17,9 +17,9 @@ base_url = ''
 base_url = comp_mirrors[0] if !comp_mirrors.empty?
 # Search for cloud mirror if no mirrors added
 if base_url.empty?
-  cloud_mirrors = JSON.parse(node[:workorder][:services][:mirror][@cloud_name][:ciAttributes][:mirrors]) 
+  cloud_mirrors = JSON.parse(node[:workorder][:services][:mirror][@cloud_name][:ciAttributes][:mirrors])
   base_url = cloud_mirrors[@cookbook_name] if !cloud_mirrors.nil? && cloud_mirrors.has_key?(@cookbook_name)
-end  
+end
 
 # If URL not found in cloud/comp mirrors use defaults
 if base_url.empty? 
@@ -34,7 +34,7 @@ end
 node.set[:elasticsearch][:cluster][:name] = ci["cluster_name"]
 
 if node[:elasticsearch][:version].start_with?("2")
-  node.set[:elasticsearch][:network][:host] = "0.0.0.0"
+  node.set[:elasticsearch][:network][:host] = node[:ipaddress]
 end
 
 # === INDEX

--- a/components/cookbooks/kibana/metadata.rb
+++ b/components/cookbooks/kibana/metadata.rb
@@ -22,13 +22,13 @@ attribute 'src_url',
 attribute 'version',
           :description => 'Version',
           :required => 'required',
-          :default => '4.1.0',
+          :default => '4.1.2',
           :format => {
 		:important => true,
               	:help => 'Version of ElasticSearch',
               	:category => '2.Global',
               	:order => 1,
-              	:form => { 'field' => 'select', 'options_for_select' => [['4.1.2', '4.1.2'], ['4.2.2', '4.2.2'], ['4.5.1', '4.5.1'], ['4.3.2', '4.3.2']] }
+              	:form => { 'field' => 'select', 'options_for_select' => [['4.1.2', '4.1.2'], ['4.2.2', '4.2.2'], ['4.3.2', '4.3.2']] }
           }
 
 attribute 'install_path',

--- a/components/cookbooks/kibana/templates/default/kibanaconfig.rb.erb
+++ b/components/cookbooks/kibana/templates/default/kibanaconfig.rb.erb
@@ -1,85 +1,77 @@
 # Kibana is served by a back end server. This controls which port to use.
-# server.port: 5601
 port: <%= node['kibana']['port'] %>
 
 # The host to bind the server to.
-# server.host: "0.0.0.0"
 host: <%= node['kibana']['interface'] %>
-#KibanaHost = <%= node['kibana']['interface'] %>
-
-# If you are running kibana behind a proxy, and want to mount it at a path,
-# specify that path here. The basePath can't end in a slash.
-# server.basePath: ""
-
-# The maximum payload size in bytes on incoming server requests.
-# server.maxPayloadBytes: 1048576
 
 # The Elasticsearch instance to use for all your queries.
-# elasticsearch.url: "http://localhost:9200"
-#Elasticsearch = <%= node['kibana']['elasticsearch_cluster_url'] %>
 elasticsearch_url: <%= node['kibana']['elasticsearch_cluster_url'] %>
 
-#ElasticsearchTimeout = 500
 # preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
 # then the host you use to connect to *this* Kibana instance will be sent.
-# elasticsearch.preserveHost: true
+elasticsearch_preserve_host: true
 
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations
 # and dashboards. It will create a new index if it doesn't already exist.
-# kibana.index: ".kibana"
+kibana_index: ".kibana"
+
+# If your Elasticsearch is protected with basic auth, this is the user credentials
+# used by the Kibana server to perform maintence on the kibana_index at statup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied thorugh
+# the Kibana server)
+# kibana_elasticsearch_username: user
+# kibana_elasticsearch_password: pass
+
+# If your Elasticsearch requires client certificate and key
+# kibana_elasticsearch_client_crt: /path/to/your/client.crt
+# kibana_elasticsearch_client_key: /path/to/your/client.key
+
+# If you need to provide a CA certificate for your Elasticsarech instance, put
+# the path of the pem file here.
+# ca: /path/to/your/CA.pem
 
 # The default application to load.
-# kibana.defaultAppId: "discover"
-
-# If your Elasticsearch is protected with basic auth, these are the user credentials
-# used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana
-# users will still need to authenticate with Elasticsearch (which is proxied through
-# the Kibana server)
-# elasticsearch.username: "user"
-# elasticsearch.password: "pass"
-
-# SSL for outgoing requests from the Kibana Server to the browser (PEM formatted)
-# server.ssl.cert: /path/to/your/server.crt
-# server.ssl.key: /path/to/your/server.key
-
-# Optional setting to validate that your Elasticsearch backend uses the same key files (PEM formatted)
-# elasticsearch.ssl.cert: /path/to/your/client.crt
-# elasticsearch.ssl.key: /path/to/your/client.key
-
-# If you need to provide a CA certificate for your Elasticsearch instance, put
-# the path of the pem file here.
-# elasticsearch.ssl.ca: /path/to/your/CA.pem
-
-# Set to false to have a complete disregard for the validity of the SSL
-# certificate.
-# elasticsearch.ssl.verify: true
+default_app_id: "discover"
 
 # Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
 # request_timeout setting
-# elasticsearch.pingTimeout: 1500
+# ping_timeout: 1500
 
 # Time in milliseconds to wait for responses from the back end or elasticsearch.
 # This must be > 0
-# elasticsearch.requestTimeout: 30000
+request_timeout: 300000
 
 # Time in milliseconds for Elasticsearch to wait for responses from shards.
 # Set to 0 to disable.
-# elasticsearch.shardTimeout: 0
+shard_timeout: 0
 
 # Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
-# elasticsearch.startupTimeout: 5000
+# startup_timeout: 5000
+
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+verify_ssl: true
+
+# SSL for outgoing requests from the Kibana Server (PEM formatted)
+# ssl_key_file: /path/to/your/server.key
+# ssl_cert_file: /path/to/your/server.crt
 
 # Set the path to where you would like the process id file to be created.
-# pid.file: /var/run/kibana.pid
+# pid_file: /var/run/kibana.pid
 
 # If you would like to send the log output to a file you can set the path below.
-logging.dest: /var/log/messages
+# This will also turn off the STDOUT log output.
+# log_file: ./kibana.log
 
-# Set this to true to suppress all logging output.
-# logging.silent: false
-
-# Set this to true to suppress all logging output except for error messages.
-# logging.quiet: false
-
-# Set this to true to log all events, including system usage information and all requests.
-logging.verbose: true
+# Plugins that are included in the build, and no longer found in the plugins/ folder
+bundled_plugin_ids:
+- plugins/dashboard/index
+- plugins/discover/index
+- plugins/doc/index
+- plugins/kibana/index
+- plugins/markdown_vis/index
+- plugins/metric_vis/index
+- plugins/settings/index
+- plugins/table_vis/index
+- plugins/vis_types/index
+- plugins/visualize/index

--- a/packs/es.rb
+++ b/packs/es.rb
@@ -5,12 +5,24 @@ description  'ElasticSearch With LB'
 type         'Platform'
 category     'Search Engine'
 
+platform :attributes => {'autoreplace' => 'false'}
+
 # Overriding the default compute
 resource 'compute',
          :attributes => {
            'ostype' => 'default-cloud',
            'size' => 'M'
          }
+
+
+resource "lb",
+  :except => [ 'single' ],
+  :design => true,
+  :cookbook => "oneops.1.lb",
+  :requires => { "constraint" => "1..1", "services" => "compute,lb,dns" },
+  :attributes => {
+    "listeners" => '["http 9200 http 9200"]',
+}
 
 resource 'user-app',
          :cookbook => 'oneops.1.user',
@@ -50,7 +62,7 @@ resource 'elasticsearch',
          :design => true,
          :requires => {'constraint' => '1..*', 'services' => 'mirror'},
          :attributes => {
-             'version' => '1.1.1'
+             'version' => '1.7.1'
          },
          :monitors => {
              'Log' => {:description => 'Log',

--- a/packs/kibana.rb
+++ b/packs/kibana.rb
@@ -4,6 +4,8 @@ description   "Kibana"
 type          "Platform"
 category      "Search Engine"
 
+platform :attributes => {'autoreplace' => 'false'}
+
 environment "single", {}
 environment "redundant", {}
 
@@ -13,6 +15,15 @@ resource 'compute',
          :attributes => {'ostype' => 'default-cloud',
                          'size' => 'S'
          }
+
+resource "lb",
+  :except => [ 'single' ],
+  :design => true,
+  :cookbook => "oneops.1.lb",
+  :requires => { "constraint" => "1..1", "services" => "compute,lb,dns" },
+  :attributes => {
+    "listeners" => '["http 5601 http 5601"]',
+}
 
 resource "user-app",
          :cookbook => "oneops.1.user",
@@ -34,8 +45,8 @@ resource "kibana",
              'install_type' => 'binary',
              'src_url' => 'https://download.elastic.co/kibana/kibana',
              'install_path' => '/app/kibana',
-             'version' => '4.1',
-             'port' => '2601',
+             'version' => '4.1.2',
+             'port' => '5601',
              'kibana_user' => 'app',
              'kibana_group' => 'app',
              'log_dir' =>'/log/kibana'


### PR DESCRIPTION
(1) add `http 9200 http 9200` mapping to ES LB
(2) add `http 5601 http 5601` mapping to Kibana LB
(3) when ES version > 2.0, `network.host` can not be `0.0.0.0`, because each ES node will bind to 127.0.0.1 with 9200 port. The result is: whole ES cluster can not be accessed via FQDN -> LB -> ip address. (e.g. `telnet ip 9200` refuses the connection - only `telnet localhost 9200` will work)
(4) Kibana config file seems outdated. Especially `bundled_plugin_ids` section is missing in old config file.
(5) ES default version is updated to 1.7.1
(6) fix wrong Kibana port (2601) in Kibana pack file