### PR TITLE
Fixing lvcreate error while deploying azure datadisk

### DIFF
--- a/components/cookbooks/volume/recipes/add.rb
+++ b/components/cookbooks/volume/recipes/add.rb
@@ -264,7 +264,6 @@ ruby_block 'create-iscsi-volume-ruby-block' do
           dev_list += dev_id+" "
           i+=1
         end
-	newDevicesAttached = dev_list
 
         # wait until all are attached
         fin = false
@@ -297,7 +296,7 @@ ruby_block 'create-iscsi-volume-ruby-block' do
         end
 
       end
-
+      newDevicesAttached = dev_list
       if node.workorder.rfcCi.ciAttributes.has_key?("mode")
         mode = node.workorder.rfcCi.ciAttributes["mode"]
       end


### PR DESCRIPTION
Empty device is passed to lvcreate in the case of non-raid mode of volume component deployment in azure, resulting in lvcreate error. 