### PR TITLE
override ssh_interactive_cmd due to windows cygwin does not like "-t -t"

### DIFF
--- a/components/cookbooks/compute/recipes/ssh_cmd_for_remote.rb
+++ b/components/cookbooks/compute/recipes/ssh_cmd_for_remote.rb
@@ -79,9 +79,8 @@ ruby_block 'ssh cmds' do
     node.set[:scp_cmd] = "scp -ri #{ssh_key_file} #{ssh_options} SOURCE #{user}@#{ip}:DEST "
     node.set[:rsync_cmd] = "rsync #{bwlimit} -az --exclude=*.md --exclude=*.png -e \"ssh -i #{ssh_key_file} #{ssh_options}\" SOURCE #{user}@#{ip}:DEST "
 
-    os_type = node.ostype
-    if os_type =~ /windows/
-      #Need to change command. Windows cygwin does not like "-t -t" parameters
+    # override ssh_interactive_cmd due to windows cygwin does not like "-t -t" parameters      
+    if os['ciAttributes']['ostype'] =~ /win/
       node.set[:ssh_interactive_cmd] = "ssh -i #{ssh_key_file} #{ssh_options} #{user}@#{ip} "
     end
 


### PR DESCRIPTION
parameters