### PR TITLE
increase wait time for windows computes to come online

### DIFF
--- a/components/cookbooks/compute/recipes/base.rb
+++ b/components/cookbooks/compute/recipes/base.rb
@@ -44,7 +44,7 @@ ruby_block 'install base' do
     end
 
     # add repo_list from os
-    if node.has_key?("repo_list") && !node.repo_list.nil?
+    if node.has_key?("repo_list") && node.repo_list.size > 0
       Chef::Log.info("adding compute-level repo_list: #{node.repo_list}")
       repo_cmds += JSON.parse(node.repo_list)
     end


### PR DESCRIPTION
60 seconds just isn't long enough for windows computes to come online.  It fails 1 to 2 times and eventually succeeds, so I increased it to 150 seconds.