### PR TITLE
added get_instance_id method

### DIFF
--- a/components/cookbooks/vsphere/recipes/add_node.rb
+++ b/components/cookbooks/vsphere/recipes/add_node.rb
@@ -86,15 +86,10 @@ network_interface = get_network_interface(compute_provider, service_compute)
 Chef::Log.info("configuring virtual machine")
 vm_attributes = get_virtual_machine_attributes(service_compute, cpu_size, memory_size, volumes, network_interface)
 
-instance_id = nil
-# keep instance_id nil for replace
-if node.workorder.rfcCi.rfcAction != 'replace'
-  instance_id = node[:compute][:instance_id]
-end
-  
-if !instance_id.nil?
+rfc_action = rfcCi[:rfcAction]
+if rfc_action == 'update'
   Chef::Log.info("Updating VM ..... " + node[:server_name].to_s)
-  virtual_machine_manager = VirtualMachineManager.new(compute_provider, public_key, instance_id)
+  virtual_machine_manager = VirtualMachineManager.new(compute_provider, public_key, node[:server_name])
 else
   Chef::Log.info("Creating VM ..... " + node[:server_name].to_s)
   start_time = Time.now

--- a/components/cookbooks/vsphere/recipes/del_node.rb
+++ b/components/cookbooks/vsphere/recipes/del_node.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../../libraries/virtual_machine_manager', __FILE__)
 require File.expand_path('../../libraries/models/tenant_model', __FILE__)
 
-compute_attributes =  node[:workorder][:rfcCi][:ciAttributes]
 cloud_name = node[:workorder][:cloud][:ciName]
 service_compute = node[:workorder][:services][:compute][cloud_name][:ciAttributes]
 
@@ -15,7 +14,7 @@ Chef::Log.info("Searching for VM ..... " + node[:server_name].to_s)
 start_time = Time.now
 Chef::Log.info("start time " + start_time.to_s)
 public_key = node.workorder.payLoad[:SecuredBy][0][:ciAttributes][:public]
-virtual_machine_manager = VirtualMachineManager.new(compute_provider, public_key, compute_attributes[:instance_id])
+virtual_machine_manager = VirtualMachineManager.new(compute_provider, public_key, node[:server_name])
 if virtual_machine_manager.delete
   Chef::Log.info("deleted instance")
 end


### PR DESCRIPTION
--This fix applies to the following error (ERROR: Cloning instance failed: DuplicateName:) during retries due to a fatal error. 