### PR TITLE
Remove OO expression from pattern metadata

### DIFF
--- a/components/cookbooks/fqdn/metadata.rb
+++ b/components/cookbooks/fqdn/metadata.rb
@@ -21,7 +21,7 @@ attribute 'aliases',
   :format => {
     :help => 'List of additional short-name aliases to be configured in the DNS service (Note: the FQDN record of these CNAME aliases will include the environment subdomain)',
     :category => '1.Global',
-    :pattern => '[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])|(.*\$OO_.*)',
+    :pattern => '[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])',
     :order => 1
   }
 
@@ -31,7 +31,7 @@ attribute 'full_aliases',
   :format => {
     :help => 'List of additional full-domain name aliases to be configured in the DNS service (Note: the FQDN record of these CNAME aliases will *not* include the environment subdomain)',
     :category => '1.Global',
-    :pattern => '([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])|(.*\$OO_.*)',
+    :pattern => '([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])',
     :order => 2
   }
 


### PR DESCRIPTION
OO Variable expressions will be automatically handled in the application.