### PR TITLE
rollback the addition of try-catch in install_base.ps1

### DIFF
--- a/components/cookbooks/compute/files/default/install_base.ps1
+++ b/components/cookbooks/compute/files/default/install_base.ps1
@@ -60,8 +60,7 @@ $chocoTempFile = "c:\chocotemp\choco.zip"
 Write-Output "Downloading chocolatey ..."
 Download-File $proxy $chocoPkg $chocoTempDir $chocoTempFile
 
-try
-{
+
 Set-Location $chocoTempDir
 
 Write-Output "Extracting chocolatey zipfile "
@@ -135,9 +134,3 @@ Set-Content C:\cygwin64\opt\oneops\rubygems_proxy $gemRepo
 
 Set-Location "C:\"
 Write-Output "End of windows install_base script"
-}
-catch 
-{
-    Write-Error $_.Exception.Message
-    exit 1
-}


### PR DESCRIPTION
Removing try-catch for the time being. Once all the issues with chocolatey have been figured out, we can put try-catch back.