### PR TITLE
Updating repository Value: https://github.com/oneops/circuit-oneops-1/issues/541

### DIFF
--- a/components/cookbooks/es/libraries/install_plugin.rb
+++ b/components/cookbooks/es/libraries/install_plugin.rb
@@ -45,7 +45,7 @@ module Extensions
         system clean_plugin_kopf
 
         if url.nil?
-           command = "/usr/local/bin/plugin -install #{name}/#{version}"
+           command = "/usr/local/bin/plugin install #{name}/#{version}"
         elsif version.start_with?("1")
           command = "/usr/local/bin/plugin --url #{url}/elasticsearch-kopf/1.1/elasticsearch-kopf-1.1.zip --install kopf"
         elsif version.start_with?("2")

--- a/components/cookbooks/es/recipes/default.rb
+++ b/components/cookbooks/es/recipes/default.rb
@@ -231,7 +231,7 @@ end
 #TODO : Can externalize  in meta-data. For now adding just the KOPF plugin
 
 if node.elasticsearch[:download_url].include? "download.elastic.co"
-  install_plugin 'lmenezes/elasticsearch-kopf' , 'version' => '#{node.elasticsearch[:version]}'
+  install_plugin 'lmenezes/elasticsearch-kopf' , 'version' => "#{node.elasticsearch[:version]}"
 else
   url = node.elasticsearch[:base_url]
   install_plugin "elasticsearch-kopf", 'url' => "#{url}", 'version' => "#{node.elasticsearch[:version]}"

--- a/components/cookbooks/es/recipes/wire_ci_attr.rb
+++ b/components/cookbooks/es/recipes/wire_ci_attr.rb
@@ -23,6 +23,7 @@ end
 
 # If URL not found in cloud/comp mirrors use defaults
 if base_url.empty? 
+  node.set[:elasticsearch][:repository]    = "elasticsearch/elasticsearch”
   node.set[:elasticsearch][:download_url]  = [node.elasticsearch[:host], node.elasticsearch[:repository], node.elasticsearch[:filename]].join('/')  
 else
   node.set[:elasticsearch][:download_url]  = [base_url, node.elasticsearch[:repository], node.elasticsearch[:filename]].join('/')


### PR DESCRIPTION
As per the code download url is formed as : https://download.elastic.co/elasticsearch/1.7.1/elasticsearch-1.7.1.tar.gz
but working url : https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz