### PR TITLE
changes for missing quote, deprecated apiserver flag, fix for contain…

### DIFF
--- a/components/cookbooks/container-app/metadata.rb
+++ b/components/cookbooks/container-app/metadata.rb
@@ -26,6 +26,7 @@ attribute 'deployment_yaml',
 attribute 'variables',
   :description => "Variables in yaml",
   :data_type => "hash",
+  :default => '{}',
   :format => {
     :help => 'map of variable/string to replace (key) with value',
     :category => '1.Content',

--- a/components/cookbooks/kubernetes/templates/default/apiserver.erb
+++ b/components/cookbooks/kubernetes/templates/default/apiserver.erb
@@ -7,7 +7,7 @@
 #
 
 # The address on the local server to listen to.
-KUBE_API_ADDRESS="--address=<%= node['kube']['api']['bind-address'] %>"
+KUBE_API_ADDRESS="--insecure-bind-address=<%= node['kube']['api']['bind-address'] %>"
 
 # The port on the local server to listen on.
 KUBE_API_PORT="--insecure-port=<%= node['kube']['api']['bind-port'] %>"

--- a/components/cookbooks/kubernetes/templates/default/proxy.erb
+++ b/components/cookbooks/kubernetes/templates/default/proxy.erb
@@ -12,4 +12,4 @@ master = lbs.first['ciAttributes']['dns_record']
 %>
 KUBE_MASTER="--master=<%= master %>:8080"
 
-KUBE_LOG_LEVEL="--v=<%= node.kubernetes.log_level %>
+KUBE_LOG_LEVEL="--v=<%= node.kubernetes.log_level %>"


### PR DESCRIPTION
3 changes for
Flag --address has been deprecated, see --insecure-bind-address instead. (/etc/kubernetes/apiserver)
missing " quote in proxy args
Fix for container-apps with no variables. (ERROR: A JSON text must at least contain two octets!)