### PR TITLE
Updating k8s version of running cluster

### DIFF
--- a/components/cookbooks/kubernetes/recipes/install.rb
+++ b/components/cookbooks/kubernetes/recipes/install.rb
@@ -28,6 +28,8 @@ unless installed
     
   end
   pkg_name = "kubernetes.tar.gz"
+  versioned_pkg_name = "kubernetes-v#{node.workorder.rfcCi.ciAttributes.version}.tar.gz"
+  pkg_version = node.workorder.rfcCi.ciAttributes.version
   pkg_url = mirror+"/kubernetes/releases/download/v#{node.workorder.rfcCi.ciAttributes.version}/#{pkg_name}"  
   
   # download kubernetes package
@@ -35,14 +37,14 @@ unless installed
   if node.kubernetes.has_key?('download_args')
     download_args = JSON.parse(node.kubernetes.download_args).join(' ')
   end
-  execute "wget -q #{download_args} -c #{pkg_url} -O #{download_dir}/#{pkg_name}" do
+  execute "wget -q #{download_args} -c #{pkg_url} -O #{download_dir}/#{versioned_pkg_name}" do
     timeout 10800
   end
   
   # extract kubernetes package
-  execute "extract package #{pkg_name}" do
+  execute "extract package #{versioned_pkg_name}" do
     cwd download_dir
-    command "tar xf #{pkg_name} && tar xf kubernetes/server/kubernetes-server-linux-amd64.tar.gz"
+    command "tar xf #{versioned_pkg_name} && tar xf kubernetes/server/kubernetes-server-linux-amd64.tar.gz"
   end
   
   # copy kubernetes bin to /usr/bin dir


### PR DESCRIPTION
changes to support version upgrade of kubernetes, fix for failing download of new version of file when old version existed.
wget -q  -c ******download/v1.5.1/kubernetes.tar.gz -O /opt/kubernetes.tar.gz command was not overwriting existing file due "-c" flag for continue download. This change used versioned file name to avoid such problem