### PR TITLE
Default Postgres archive_mode to off

### DIFF
--- a/components/cookbooks/postgresql/templates/default/postgresql.conf.erb
+++ b/components/cookbooks/postgresql/templates/default/postgresql.conf.erb
@@ -507,6 +507,8 @@
   'shared_buffers' => "24MB",            # min 128kB or max_connections*16kB
   'log_line_prefix' => "'%t '",            # special values:
   'datestyle' => "'iso, mdy'",
+  'archive_mode' => "off",        # allows archiving to be done
+  'archive_command' => "'cp \"%p\" #{node[:postgresql][:dir]}/archivedir/\"%f\"'",        # command to use to archive a logfile segment
   'default_text_search_config' => "'pg_catalog.english'"
 }.merge(JSON.parse(node.workorder.rfcCi.ciAttributes[:postgresql_conf])).each do |param,value| %>
 	<%= param %> = <%= value %>
@@ -517,8 +519,6 @@
       <% if node.workorder.cloud.ciAttributes.priority.to_i < 2 %>		
 		<%- {
 		  'wal_level' => "hot_standby",
-		  'archive_mode' => "on",        # allows archiving to be done
-		  'archive_command' => "'cp \"%p\" #{node[:postgresql][:dir]}/archivedir/\"%f\"'",        # command to use to archive a logfile segment
 		  'max_wal_senders' => 3,
 		  'wal_keep_segments' => 32
 		}.each do |param,value| %>
@@ -535,9 +535,6 @@
 <%   else %>
 	<%- {
 	  'wal_level' => "archive",
-	  'archive_mode' => "on",        # allows archiving to be done
-	  'archive_command' => "'cp \"%p\" #{node[:postgresql][:dir]}/archivedir/\"%f\"'",        # command to use to archive a logfile segment
-	  'archive_timeout' => 0      # force a logfile segment switch after this
 	}.each do |param,value| %>
 		<%= param %> = <%= value %>
 	<% end %>


### PR DESCRIPTION
@schwankl I'd like to have these changes merged to the postgres pack.  Please let me know your thoughts.

1. I have defaulted `archive_mode` to off.  I believe that this should not be on by default without some kind of plan in place to deal with the archived WAL segments.  Otherwise, users will be surprised by their disks filling up with archived segments that they didn't ask for

1. I left the `archive_command` in place so that it will work as designed should the user want to turn `archive_mode` on.

1. I moved both of those statements to the top level hash that gets merged with the user specified postgres conf keys.  This allows the user to override them if needed.

1. I removed the `archive_timeout = 0`  as this appears to be the default value.