### PR TITLE
Zookeeper: fix check_cluster_health.sh

### DIFF
--- a/components/cookbooks/zookeeper/recipes/add.rb
+++ b/components/cookbooks/zookeeper/recipes/add.rb
@@ -9,14 +9,14 @@
 zk_basename = "zookeeper-#{node[:zookeeper][:version]}"
 ci = node.workorder.rfcCi.ciAttributes;
 zk_base_url = ci['mirror']
-zk_download_url = "#{zk_base_url}"+"#{zk_basename}/"+"#{zk_basename}.tar.gz"
+zk_download_location = "#{zk_base_url}"+"#{zk_basename}/"+"#{zk_basename}.tar.gz"
 
-Chef::Log.info("download url from #{zk_download_url} ")
+Chef::Log.info("download url from #{zk_download_location} ")
 
 remote_file ::File.join(Chef::Config[:file_cache_path], "#{zk_basename}.tar.gz") do
   owner "root"
   mode "0644"
-  source zk_download_url
+  source zk_download_location
   action :create
 end
 
@@ -68,17 +68,7 @@ service "start-zookeeper-server" do
  # notifies :create, resources("ruby_block[zookeeper-server]"), :immediately
 end
 
-# Copy the monitoring script to machine, get list of IPs first
-nodes = node.workorder.payLoad.RequiresComputes
-string_of_ips = ""
-nodes.each do |n|   
-   if string_of_ips.length == 0
-     string_of_ips = n[:ciAttributes][:dns_record]
-   else
-     string_of_ips = string_of_ips + " " + n[:ciAttributes][:dns_record]      
-   end   
-  end
-Chef::Log.info(string_of_ips)
+Chef::Log.info(node[:string_of_hostname])
 
 Chef::Log.info("Copying monitoring script")
 check_cluster_health = '/opt/nagios/libexec/check_cluster_health.sh'
@@ -89,6 +79,6 @@ template check_cluster_health do
   mode "0755"
   #  action :create_if_missing
   variables({
-                :string_of_ips => string_of_ips                
+                :string_of_ips => node[:string_of_hostname]                
             })
 end

--- a/components/cookbooks/zookeeper/recipes/config_files.rb
+++ b/components/cookbooks/zookeeper/recipes/config_files.rb
@@ -126,6 +126,8 @@ else
   end
 end
 
+node.set[:string_of_hostname] = zookeeper_hosts.keys.join(" ")
+
 # use explicit value if set, otherwise make the leader a server iff there are
 # four or more zookeepers kicking around
 

--- a/components/cookbooks/zookeeper/templates/default/check_cluster_health.sh.erb
+++ b/components/cookbooks/zookeeper/templates/default/check_cluster_health.sh.erb
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-clientPort="2181"
+clientPort=<%= node['zookeeper']['client_port'] %>
 declare -i returnCode=0
 declare -i num_active_nodes=0
 active_nodes=""
 
-declare -a ips=(<%= @string_of_ips %>)
+declare -a ips=(<%= @string_of_hostname %>)
 declare -i total_nodes=${#ips[@]}
 
 ## Iterate over all IPs
@@ -28,7 +28,9 @@ do
 		num_active_nodes=$(($num_active_nodes+1))
 		active_nodes="$active_nodes $ip(leader)"
 	elif [ "$srvrOut" == "observer" ]; then
-		not_used="true"	
+		not_used="true"
+    elif [ "$srvrOut" == "standalone" ]; then
+        num_active_nodes=$(($num_active_nodes+1))
 	else
 		#"ERROR: $ip is not a leader, follower or an observer, but returned 'imok' response"
 		returnCode=0


### PR DESCRIPTION
(1) use hostname to replace IP
(2) consider 1-node zookeeper, where status return is `standalone`
(3) `clientPort` should read from the CiAttribute, rather than static (2181)