### PR TITLE
Removing the dependancy between objectstore and user components

### DIFF
--- a/components/cookbooks/swift/attributes/default.rb
+++ b/components/cookbooks/swift/attributes/default.rb
@@ -22,9 +22,3 @@ default[:swift][:username] = username
 default[:swift][:password] = password
 default[:swift][:authstrategy] = cloud_service[:ciAttributes][:authstrategy]
 default[:swift][:homepath]= '/etc'
-
-for entry in node.workorder.payLoad.DependsOn
-  if entry.ciAttributes.has_key?("home_directory")
-    default[:swift][:homepath]=entry.ciAttributes[:home_directory]
-  end
-end

--- a/packs/base.rb
+++ b/packs/base.rb
@@ -762,7 +762,8 @@ end
   { :from => 'artifact',    :to => 'os' },    
   { :from => 'sensuclient', :to => 'compute'  },
   { :from => 'library',     :to => 'os' },
-  { :from => 'objectstore',  :to => 'compute'}
+  { :from => 'objectstore',  :to => 'compute'},
+  { :from => 'objectstore',  :to => 'user'}
 ].each do |link|
   relation "#{link[:from]}::depends_on::#{link[:to]}",
     :relation_name => 'DependsOn',

--- a/packs/base.rb
+++ b/packs/base.rb
@@ -762,8 +762,7 @@ end
   { :from => 'artifact',    :to => 'os' },    
   { :from => 'sensuclient', :to => 'compute'  },
   { :from => 'library',     :to => 'os' },
-  { :from => 'objectstore',  :to => 'compute'},
-  { :from => 'objectstore',  :to => 'user'}
+  { :from => 'objectstore',  :to => 'compute'}
 ].each do |link|
   relation "#{link[:from]}::depends_on::#{link[:to]}",
     :relation_name => 'DependsOn',


### PR DESCRIPTION
There is no need for objectstore depends on user. Hence removing it.