### PR TITLE
New logic to force rebuild of /etc/resolv.conf with new settings from dhcp server.

### DIFF
--- a/components/cookbooks/os/recipes/reconfig-network.rb
+++ b/components/cookbooks/os/recipes/reconfig-network.rb
@@ -10,5 +10,30 @@ node.set["workorder"]["rfcCi"]["ciAttributes"]["dhclient"] = node.workorder.ci.c
 node.set["vmhostname"] = node.workorder.box.ciName+'-'+node.workorder.cloud.ciId.to_s+'-'+node.workorder.ci.ciName.split('-').last.to_i.to_s+'-'+ node.workorder.ci.ciId.to_s
 node.set["full_hostname"] = node["vmhostname"]+'.'+node["customer_domain"]
 
+# Rename existing dhclient.conf for backup
+execute "mv -f /etc/dhcp/dhclient.conf /etc/dhcp/dhclient.conf.#{Time.now.to_i}" do
+  only_if { ::File.exist?('/etc/dhcp/dhclient.conf') }
+end
+
+dhclient_cmdline = "/sbin/dhclient"
+
+# try to use options that its running with
+dhclient_ps = `ps auxwww|grep -v grep|grep dhclient`
+if dhclient_ps.to_s =~ /.*:\d{2} (.*dhclient.*)/
+  dhclient_cmdline = $1
+end
+
+dhclient_cmdline = dhclient_cmdline + " &"
+
+# kill dhclient so we can regenerate /etc/resolv.conf
+`pkill -f dhclient`
+
+# Start dhclient again to get default values from dhcp server
+output = `#{dhclient_cmdline}`
+
+if node.["workorder"]["rfcCi"]["ciAttributes"]["dhclient"] != 'true'
+  `pkill -f dhclient`
+end
+
 # run the network script
 include_recipe "os::network"


### PR DESCRIPTION
    Existing logic does not rebuild /etc/resolv.conf because of existing
    dhclient.conf already has existing DNS servers values.  New logic is to
    rename existing dhclient.conf with epoch timestamp and restart dhclient.
    This will force /etc/resolv.conf to be regenerated thus has new DNS
    servers values so we use to reconfig necessary network settings.