### PR TITLE
Fixed secgroup rule for Ping.  It was broken in recent updates.

### DIFF
--- a/packs/ganglia-server-v1.rb
+++ b/packs/ganglia-server-v1.rb
@@ -18,14 +18,14 @@ resource 'secgroup',
          :attributes => {
            # Port configuration:
            #
-           #    -1:  Ping
+           #  null:  Ping
            #    22:  SSH
            #    80:  Ganglia Server
            # 8800-8899: Server gmond instances
            # 60000:  For mosh
            #
            "inbound" => '[
-               "-1 -1 icmp 0.0.0.0/0",
+               "null null 4 0.0.0.0/0",
                "22 22 tcp 0.0.0.0/0",
                "80 80 tcp 0.0.0.0/0",
                "8800 8899 udp 0.0.0.0/0",


### PR DESCRIPTION
This fix allows the ganglia-server-v1 pack to be deployed with the most recent OneOps code.  The secgroup rule that enabled ping was broken after recent updates to OneOps...this allows the default pack configuration to work.