### PR TITLE
added protocol type to generic healthmonitor name

### DIFF
--- a/components/cookbooks/netscaler/recipes/get_monitor_name.rb
+++ b/components/cookbooks/netscaler/recipes/get_monitor_name.rb
@@ -5,7 +5,7 @@
 if node.workorder.has_key?("rfcCi")
   lbCi = node.workorder.rfcCi
 else
-  lbCi = node.workorder.ci  
+  lbCi = node.workorder.ci
 end
 
 
@@ -18,12 +18,12 @@ end
 
 previous_iport_map = {}
 if lbCi.has_key?("ciBaseAttributes") &&
-   lbCi["ciBaseAttributes"].has_key?("listeners")  
-  
+   lbCi["ciBaseAttributes"].has_key?("listeners")
+
   JSON.parse(lbCi["ciBaseAttributes"]["listeners"]).each do |lb|
     previous_iport = lb.split(" ").last
     previous_iport_map[previous_iport] = 1
-  end  
+  end
 end
 
 ecv_map = JSON.parse(lbCi["ciAttributes"]["ecv_map"])
@@ -38,19 +38,19 @@ lb_ci_id = lbCi["ciId"].to_s
 monitors = []
 old_monitor_names = []
 iport_map.each_pair do |iport,protocol|
-  
+
   iport_name = iport
   if iport.downcase == 'any'
     next
-  end  
+  end
   base_monitor_name =  [env_name, assembly_name, platform_name, iport, lb_ci_id].join("-") + "-monitor"
-  
+
   sg_name = [env_name, platform_name, cloud_name, iport, lb_ci_id, "svcgrp"].join("-")
   # truncate for netscaler max monitor name length of 31 - port can be 5
   if base_monitor_name.length > 26
     base_monitor_name = lb_ci_id + "-"+ iport +"-monitor"
   end
-  
+
   monitor_request = 'get /'
   if ecv_map.has_key?(iport)
     monitor_request = ecv_map[iport].downcase
@@ -60,38 +60,43 @@ iport_map.each_pair do |iport,protocol|
   orig_monitor_name = ""
   if ["get /","head /"].include?(monitor_request)
     # orig monitor name to migrate in servicegroup before binding
-    orig_monitor_name  = base_monitor_name    
-    base_monitor_name = "generic-" + monitor_request.gsub(' ','-').gsub('/','slash')
+    orig_monitor_name  = base_monitor_name
+    case protocol
+    when 'http'
+      base_monitor_name = "generic-" + monitor_request.gsub(' ','-').gsub('/',protocol)
+    else
+      base_monitor_name = "generic-" + protocol
+    end 
   else
     # check for non-generic bindings and add to old monitors to unbind
-    existing_bindings =    
+    existing_bindings =
     resp_obj = JSON.parse(node.ns_conn.request(:method=>:get,
       :path=>"/nitro/v1/config/servicegroup_lbmonitor_binding/#{sg_name}").body)
-    
+
     if resp_obj.has_key? "servicegroup_lbmonitor_binding"
       resp_obj['servicegroup_lbmonitor_binding'].each do |binding|
-        
+
         if binding['monitor_name'] != base_monitor_name
           old_monitor_names.push binding['monitor_name']
           Chef::Log.info("adding to old monitors: #{binding['monitor_name']}")
         end
-        
+
       end
     end
-  
+
   end
-    
+
   monitor = {
-    :monitor_name => base_monitor_name, 
-    :iport => iport, 
+    :monitor_name => base_monitor_name,
+    :iport => iport,
     :protocol => protocol,
-    :sg_name => sg_name 
+    :sg_name => sg_name
   }
   if !orig_monitor_name.empty?
     monitor[:orig_monitor_name] = orig_monitor_name
   end
   monitors.push monitor
-  
+
   # setup old name to unbind and delete
   if previous_iport_map.has_key? iport
     previous_iport_map.delete iport
@@ -103,12 +108,12 @@ node.set["monitors"] = monitors
 # cleanup monitors
 previous_iport_map.keys.each do |iport|
   base_monitor_name =  [env_name, assembly_name, platform_name, iport, lb_ci_id].join("-") + "-monitor"
-  
+
   # truncate for netscaler max monitor name length of 31 - port can be 5
   if base_monitor_name.length > 26
     base_monitor_name = lb_ci_id + "-"+ iport +"-monitor"
   end
-  
+
   monitor_name = base_monitor_name
   old_monitor_names.push monitor_name
 end


### PR DESCRIPTION
This is to resolve a netscaler health monitor naming conflict in which the same name is being used for monitors regardless of their protocol type.  It is creating an issue when adding generic health monitors of different type.  This fix adds the protocol type to the name.