### PR TITLE
Revert "change DHCLIENT to true on OS component"

### DIFF
--- a/components/cookbooks/os/metadata.rb
+++ b/components/cookbooks/os/metadata.rb
@@ -132,7 +132,7 @@ attribute 'proxy_map',
 
 attribute 'dhclient',
           :description => "Keep long running dhclient after boot (not recommended if dhcp server issues)",
-          :default     => 'true',
+          :default     => 'false',
           :format      => {
             :help     => 'When selected enables long running dhclient which will manage periodic IP Address renewals. When not selected, dhclient will be stopped and IP Address will behave as if static.',
             :category => '4.Networking',


### PR DESCRIPTION
Reverts oneops/circuit-oneops-1#800

after discussing Ravi, there is a dependent PR/Bug related to this, revering back 