### PR TITLE
Add link to appropriate security group documentation

### DIFF
--- a/components/cookbooks/secgroup/doc/index.md
+++ b/components/cookbooks/secgroup/doc/index.md
@@ -1,1 +1,1 @@
-No component documentation available. Please refer to the pack documentation or [the OneOps website](http://oneops.com).
+Please refer to [Add or Delete a Security Group to Open or Close an Additional Port](http://oneops.com/user/design/add-or-delete-a-security-group-to-open-or-close-an-additional-port).


### PR DESCRIPTION
Adding security group rules requires a non-obvious format.
The documentation should be linked appropriately.