### PR TITLE
Fixing haproxy config check warning proxy timeouts

### DIFF
--- a/components/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/components/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -35,6 +35,9 @@ listen stats :<%= node.haproxy.stats_web_port %>
   mode http
   stats enable
   stats uri /
+  timeout connect         10s
+  timeout client          1m
+  timeout server          1m
 
 <% end -%>
 


### PR DESCRIPTION
When you do a haproxy status via a init script, it does a config check and throws the below error. To avoid it, I added some default timeouts for the stats proxy.


systemd[1]: Starting HAProxy Load Balancer...
systemd[1]: Started HAProxy Load Balancer.
haproxy-systemd-wrapper[1269]: haproxy-systemd-wrapper: executing /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
haproxy-systemd-wrapper[1269]: [WARNING] 128/234851 (1270) : config : missing timeouts for proxy 'stats'.
haproxy-systemd-wrapper[1269]: | While not properly invalid, you will certainly encounter various problems
haproxy-systemd-wrapper[1269]: | with such a configuration. To fix this, please ensure that all following
