### PR TITLE
Fixed a condition where max_retry_count is > 30.

### DIFF
--- a/components/cookbooks/fqdn/libraries/fqdn_base.rb
+++ b/components/cookbooks/fqdn/libraries/fqdn_base.rb
@@ -152,6 +152,10 @@ module Fqdn
         
     
     def verify(dns_name, dns_values, ns, max_retry_count=30)
+      if dns_values.count > max_retry_count
+        max_retry_count = dns_values.count + 1
+      end
+
       retry_count = 0
       dns_type = get_record_type(dns_name, dns_values)
   


### PR DESCRIPTION
    There is a hard cap of max_retry_count=30 which will fail when
    there are more values assigning to a record.

    The fix is to bump up the count to be greater then then values + 1.
