### PR TITLE
Presto V2 hostname patch

### DIFF
--- a/packs/presto-v2.rb
+++ b/packs/presto-v2.rb
@@ -648,6 +648,15 @@ resource 'java',
            'jrejdk' => 'server-jre'
          }
 
+resource "hostname",
+         :cookbook => "oneops.1.fqdn",
+         :design => true,
+         :requires => {
+           :constraint => "1..1",
+           :services => "dns",
+           :help => "hostname dns entry"
+         }
+
 resource "client-yarn",
         :cookbook => "oneops.1.hadoop-yarn-v1",
         :design => true,


### PR DESCRIPTION
Added a default hostname component to ensure that the ssh_known_hosts file is populated properly.