### PR TITLE
will help user to resize volume on ephemeral and persistent storage

### DIFF
--- a/components/cookbooks/volume/recipes/replace.rb
+++ b/components/cookbooks/volume/recipes/replace.rb
@@ -1,1 +1,12 @@
-include_recipe "volume::add"
+new_size = node.workorder.rfcCi.ciAttributes["size"].gsub(/\s+/, "")
+old_size = node.workorder.rfcCi.ciBaseAttributes[:size]
+
+#this condition will help to attach same volume component on compute replace
+if !old_size.nil? && new_size != old_size &&  old_size != "-1"
+  Chef::Log.info("Volume will be deleted and new volume will be attached to compute")
+  include_recipe "volume::delete"
+  include_recipe "volume::add"
+else
+  Chef::Log.info("Same volume will be attached to compute")
+  include_recipe "volume::add"
+end


### PR DESCRIPTION
User can change volume size in transition and mark volume component for replace. After commit and deploy, user can see resized volume. On replace compute, if persistent storage is there, it will not be replaced, same will be attached to new compute. Resizing will wipe off data.