### PR TITLE
Adding protocol check for TERMINATED_HTTPS while checking for active certificate/barbican component.

### DIFF
--- a/components/cookbooks/octavia/recipes/update.rb
+++ b/components/cookbooks/octavia/recipes/update.rb
@@ -85,7 +85,7 @@ begin
         members = initialize_members(subnet_id, iport)
         pool = initialize_pool(iprotocol, lb_attributes[:lbmethod], lb_name, members, health_monitor, stickiness, persistence_type)
         new_listener = nil
-        if !barbican_container_name.nil? && !barbican_container_name.empty?
+        if !barbican_container_name.nil? && !barbican_container_name.empty? && vprotocol == 'TERMINATED_HTTPS'
           secret_manager = SecretManager.new(service_lb_attributes[:endpoint], service_lb_attributes[:username],service_lb_attributes[:password], service_lb_attributes[:tenant] )
           container_ref = secret_manager.get_container(barbican_container_name)
           Chef::Log.info("Container_ref : #{container_ref}")


### PR DESCRIPTION

This will help in triggering barbican only when VIP protocol is
TERMINATED_HTTPS