### PR TITLE
Fixed a condition where fqdn::delete doesn't delete dc vip dns.

### DIFF
--- a/components/cookbooks/fqdn/recipes/delete.rb
+++ b/components/cookbooks/fqdn/recipes/delete.rb
@@ -63,6 +63,7 @@ if env.has_key?("global_dns") && env["global_dns"] == "true" &&
     include_recipe "azuretrafficmanager::delete"
   else
     include_recipe "netscaler::get_gslb_domain"
+    include_recipe "netscaler::get_dc_lbvserver"
     include_recipe "netscaler::delete_gslb_service"
     include_recipe "netscaler::delete_gslb_vserver"
     include_recipe "netscaler::logout"


### PR DESCRIPTION
There is an existing logic in fqdn::build_entries_list where it looks explicity
for the existence of node.dc_entry and node.is_last_active_cloud_in_dc
to determine if it satisfies criteria to delete dns entry for dc vip dns.  However,
this attribute is set in netscaler::get_dc_lbvserver, and without this recipe being
referenced first this condition wasn't met thus dc vip dns was effectively skipped
from being deleted.  To remediate this condition fqdn::delete must reference
netscaler::get_dc_lbvserver.

Once the condition is met in fqdn::build_entries_list, dc vip dns was slated to be removed
as designed.

    entries.push(node.dc_entry)
    deletable_entries.push(node.dc_entry)