### PR TITLE
Revert back the metadata name from lowercase to uppercase.

### DIFF
--- a/components/cookbooks/ansible/metadata.rb
+++ b/components/cookbooks/ansible/metadata.rb
@@ -1,4 +1,4 @@
-name             'ansible'
+name             'Ansible'
 maintainer       'OneOps'
 maintainer_email 'support@oneops.com'
 license          'Apache-2.0'


### PR DESCRIPTION
    Revert back the metadata name from lowercase to uppercase
    since the change to make lowercase compatible was rolled back
    from oneops-admin codebase (https://github.com/oneops/oneops-admin/pull/193/files)
