### PR TITLE
keypair update will not perform any action to keep footprint intact

### DIFF
--- a/components/cookbooks/keypair/recipes/update.rb
+++ b/components/cookbooks/keypair/recipes/update.rb
@@ -3,11 +3,5 @@
 # Recipe:: update
 #
 
-include_recipe "shared::set_provider"
-  OOLog.debug("node[:provider_class] ==> "+node[:provider_class])
-if node[:provider_class] =~ /azure/
-  return
-else
-  include_recipe "keypair::delete"
-  include_recipe "keypair::add"
-end
+Chef::Log.info("keypair update will not perform any action to keep footprint intact")
+return


### PR DESCRIPTION
keypair update will not perform any action to keep footprint intact, so it will in first place will not delete existing keys and re-create it.