### PR TITLE
Fixed Minor Syntax Errors

### DIFF
--- a/components/cookbooks/postgresql-governor/recipes/status.rb
+++ b/components/cookbooks/postgresql-governor/recipes/status.rb
@@ -1,4 +1,4 @@
-cmd = Mixlib::ShellOut.new("/etc/init.d/#{service governor status")
+cmd = Mixlib::ShellOut.new("/etc/init.d/#{service governor status}")
 cmd.run_command
 #cmd.error!
 #Chef::Log.info(cmd.inspect)

--- a/components/cookbooks/solrcloud/recipes/remove.rb
+++ b/components/cookbooks/solrcloud/recipes/remove.rb
@@ -5,12 +5,16 @@
 # The recipe deletes the solrcloud set up on the node marked for deletion.
 #
 
+installation_dir_path = node['installation_dir_path']
+solrmajorversion = node['solrmajorversion']
+solr_version = node['solr_version']
+
 if node['solr_version'].start_with? "4."
 	execute "tomcat#{node['tomcatversion']} stop" do
 	  command "service tomcat#{node['tomcatversion']} stop"
 	  user node['solr']['user']
 	  action :run
-	  only_if { ::File.exists?("/etc/init.d/tomcat#{node['tomcatversion']}")}
+	  only_if { ::File.exist?("/etc/init.d/tomcat#{node['tomcatversion']}")}
 	end
 
 	["/app"].each { |dir|
@@ -29,15 +33,15 @@ if node['solr_version'].start_with? "4."
 	end
 end
 
-if node['solr_version'].start_with? "5." || node['solr_version'].start_with? "6."
-	execute "solr#{node['solrmajorversion']} stop" do
-	  command "service solr#{node['solrmajorversion']} stop"
+if (node['solr_version'].start_with? "5.") || (node['solr_version'].start_with? "6.")
+	execute "solr#{solrmajorversion} stop" do
+	  command "service solr#{solrmajorversion} stop"
 	  user "root"
 	  action :run
-	  only_if { ::File.exists?("/etc/init.d/solr#{solrmajorversion}")}
+	  only_if { ::File.exist?("/etc/init.d/solr#{solrmajorversion}")}
 	end
 
-	[node['installation_dir_path']/solr"#{node['solrmajorversion']}" ,node['data_dir_path'],"/app",node['installation_dir_path']/"solr-#{node['solr_version']}"].each { |dir|
+	["#{installation_dir_path}/solr#{solrmajorversion}", node['data_dir_path'], "/app", "#{installation_dir_path}/solr-#{solr_version}"].each { |dir|
 		Chef::Log.info("deleting #{dir} for user app")
 	  	directory dir do
 	    	owner node['solr']['user']
@@ -48,13 +52,12 @@ if node['solr_version'].start_with? "5." || node['solr_version'].start_with? "6.
 	  	end
 	}
 
-	link "node['installation_dir_path']/solr#{node['solrmajorversion']}" do
+	link "node['installation_dir_path']/solr#{solrmajorversion}" do
 	  link_type :symbolic
 	  action :delete
 	end
 
-	file "/etc/init.d/solr#{node['solrmajorversion']}" do
+	file "/etc/init.d/solr#{solrmajorversion}" do
 		action :delete
 	end
 end
-

--- a/components/cookbooks/spark-v1/metadata.rb
+++ b/components/cookbooks/spark-v1/metadata.rb
@@ -225,9 +225,8 @@ attribute 'ganglia_servers',
           :format => {
               :help => 'Specify ganglia servers to point metrics to. Format HOST:PORT',
               :category => '4.Optional Services',
-              :filter => {'all' => {'editable' => 'enable_ganglia:eq:true'}},
+              :filter => {'all' => [{'editable' => 'enable_ganglia:eq:true'}, {'visible' => 'is_client_only:eq:false'}]},
               :order => 6,
-              :filter => {'all' => {'visible' => 'is_client_only:eq:false'} }
           }
 
 # Internal attributes not meant for user configuration


### PR DESCRIPTION
Fixed the following syntax errors:

components/cookbooks/postgresql-governor/recipes/status.rb:5: syntax error, unexpected tCONSTANT, expecting tSTRING_DEND
Chef::Log.info("Execution completed\n#{cmd.format_for_exception}")
                         ^
components/cookbooks/solrcloud/recipes/remove.rb:32: syntax error, unexpected tSTRING_BEG, expecting keyword_then or ';' or '\n'
...e['solr_version'].start_with? "6."
...                               ^
components/cookbooks/solrcloud/recipes/remove.rb:40: syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '('
...['installation_dir_path']/solr"#{node['solrmajorversion']}" ...
...                               ^
components/cookbooks/solrcloud/recipes/remove.rb:40: syntax error, unexpected ',', expecting end-of-input
..."#{node['solrmajorversion']}" ,node['data_dir_path'],"/app",...
...                               ^
components/cookbooks/spark-v1/metadata.rb:228: warning: duplicated key at line 230 ignored: :filter
