### PR TITLE
Modifying fqdn to utilize zone subservices over the default dns servi…

### DIFF
--- a/components/cookbooks/fqdn/recipes/get_authoritative_nameserver.rb
+++ b/components/cookbooks/fqdn/recipes/get_authoritative_nameserver.rb
@@ -1,6 +1,5 @@
 # get authoratative NS's and find one we can connect to
-cloud_name = node[:workorder][:cloud][:ciName]
-service_attrs = node[:workorder][:services][:dns][cloud_name][:ciAttributes]
+service_attrs = get_dns_service
 ns_list = `dig +short NS #{service_attrs[:zone]}`.split("\n")
 ns = nil
 ns_list.each do |n|

--- a/components/cookbooks/fqdn/recipes/get_ddns_connection.rb
+++ b/components/cookbooks/fqdn/recipes/get_ddns_connection.rb
@@ -17,8 +17,7 @@
 # Recipe:: get_ddns_connection
 #
 
-cloud_name = node[:workorder][:cloud][:ciName]
-service = node[:workorder][:services][:dns][cloud_name][:ciAttributes]
+service = get_dns_service
   
 auth_content = "key #{service[:keyname]} {\n"
 auth_content += "  secret \"#{service[:secret]}\";\n"

--- a/components/cookbooks/fqdn/recipes/get_designate_connection.rb
+++ b/components/cookbooks/fqdn/recipes/get_designate_connection.rb
@@ -20,8 +20,7 @@
 require 'excon'
 require 'json'
 
-cloud_name = node[:workorder][:cloud][:ciName]
-service = node[:workorder][:services][:dns][cloud_name][:ciAttributes]
+service = get_dns_service
 domain_name = service[:zone] 
 domain_name += "."
 

--- a/components/cookbooks/fqdn/recipes/get_fog_connection.rb
+++ b/components/cookbooks/fqdn/recipes/get_fog_connection.rb
@@ -20,7 +20,7 @@ require 'fog'
 
 cloud_name = node[:workorder][:cloud][:ciName]
 service_class = node[:workorder][:services][:dns][cloud_name][:ciClassName].split(".").last.downcase
-dns_attrs = node[:workorder][:services][:dns][cloud_name][:ciAttributes]
+dns_attrs = get_dns_service
   
 dns = nil
 domain_name = dns_attrs[:zone] 

--- a/components/cookbooks/fqdn/recipes/get_infoblox_connection.rb
+++ b/components/cookbooks/fqdn/recipes/get_infoblox_connection.rb
@@ -19,8 +19,7 @@
 
 require 'excon'
 
-cloud_name = node[:workorder][:cloud][:ciName]
-service = node[:workorder][:services][:dns][cloud_name][:ciAttributes]
+service = get_dns_service
 
 host = service[:host]
 username = service[:username]

--- a/components/cookbooks/fqdn/recipes/remove_old_aliases_ddns.rb
+++ b/components/cookbooks/fqdn/recipes/remove_old_aliases_ddns.rb
@@ -21,10 +21,7 @@
 require 'excon'
    
 # ex) customer_domain: env.asm.org.oneops.com
-customer_domain = node.customer_domain
-if node.customer_domain !~ /^\./
-  customer_domain = '.'+node.customer_domain
-end
+customer_domain = get_customer_domain
 
 # entries Array of {name:String, values:Array}
 entries = Array.new
@@ -92,8 +89,7 @@ aliases.each do |a|
   end
 
   if node.workorder.cloud.ciAttributes.priority == "1"
-     cloud_name = node.workorder.cloud.ciName
-     service = node[:workorder][:services][:dns][cloud_name][:ciAttributes]
+     service = get_dns_service
      if service[:cloud_dns_id].nil? || service[:cloud_dns_id].empty?
        Chef::Log.info(" no cloud_dns_id - service: #{service.inspect} ")
        next

--- a/components/cookbooks/fqdn/recipes/remove_old_aliases_designate.rb
+++ b/components/cookbooks/fqdn/recipes/remove_old_aliases_designate.rb
@@ -17,10 +17,7 @@
 #
           
 # ex) customer_domain: env.asm.org.oneops.com
-customer_domain = node.customer_domain
-if node.customer_domain !~ /^\./
-  customer_domain = '.'+node.customer_domain
-end
+customer_domain = get_customer_domain
 
 # entries Array of {name:String, values:Array}
 entries = Array.new

--- a/components/cookbooks/fqdn/recipes/remove_old_aliases_fog.rb
+++ b/components/cookbooks/fqdn/recipes/remove_old_aliases_fog.rb
@@ -4,10 +4,7 @@
 
           
 # ex) customer_domain: env.asm.org.oneops.com
-customer_domain = node.customer_domain
-if node.customer_domain !~ /^\./
-  customer_domain = '.'+node.customer_domain
-end
+customer_domain = get_customer_domain
 
 # entries Array of {name:String, values:Array}
 entries = Array.new

--- a/components/cookbooks/fqdn/recipes/remove_old_aliases_infoblox.rb
+++ b/components/cookbooks/fqdn/recipes/remove_old_aliases_infoblox.rb
@@ -21,10 +21,7 @@
 require 'excon'
    
 # ex) customer_domain: env.asm.org.oneops.com
-customer_domain = node.customer_domain
-if node.customer_domain !~ /^\./
-  customer_domain = '.'+node.customer_domain
-end
+customer_domain = get_customer_domain
 
 # entries Array of {name:String, values:Array}
 entries = Array.new
@@ -93,8 +90,7 @@ aliases.each do |a|
   end
 
   if node.workorder.cloud.ciAttributes.priority == "1"
-     cloud_name = node.workorder.cloud.ciName
-     service = node[:workorder][:services][:dns][cloud_name][:ciAttributes]
+     service = get_dns_service
      if service[:cloud_dns_id].nil? || service[:cloud_dns_id].empty?
        Chef::Log.info(" no cloud_dns_id - service: #{service.inspect} ")
        next

--- a/components/cookbooks/fqdn/recipes/set_dns_entries_ddns.rb
+++ b/components/cookbooks/fqdn/recipes/set_dns_entries_ddns.rb
@@ -46,8 +46,7 @@ end
 
 include_recipe "fqdn::get_ddns_connection"
 
-cloud_name = node[:workorder][:cloud][:ciName]
-domain_name = node[:workorder][:services][:dns][cloud_name][:ciAttributes][:zone]
+domain_name = get_dns_service[:zone]
 cmd_file = node.ddns_key_file + '-cmd'
 ns = node.ns
 

--- a/components/cookbooks/fqdn/recipes/set_dns_entries_infoblox.rb
+++ b/components/cookbooks/fqdn/recipes/set_dns_entries_infoblox.rb
@@ -97,7 +97,7 @@ end
 def set_is_hijackable_record(dns_name)
   
   # 'txt-' prefix due to cnames and txt records cannot exist for same name in infoblox 
-  record = { :name => 'txt-' + dns_name, :text => "hijackable_from_#{node.customer_domain}" }
+  record = { :name => 'txt-' + dns_name, :text => "hijackable_from_#{get_customer_domain}" }
   
   records = JSON.parse(node.infoblox_conn.request(:method=>:get,
     :path=>"/wapi/v1.0/record:txt", :body => JSON.dump(record) ).body)
@@ -121,9 +121,7 @@ end
 
 include_recipe "fqdn::get_infoblox_connection"
 
-cloud_name = node[:workorder][:cloud][:ciName]
-domain_name = node[:workorder][:services][:dns][cloud_name][:ciAttributes][:zone]
-view_attribute = node[:workorder][:services][:dns][cloud_name][:ciAttributes][:view_attr]
+view_attribute = get_dns_service[:view_attr]
 
 Chef::Log.debug("view_attribute: #{view_attribute}")
 
@@ -173,7 +171,7 @@ node[:entries].each do |entry|
       set_is_hijackable_record(dns_name)
     elsif node.workorder.rfcCi.ciBaseAttributes.has_key?('hijackable_full_aliases') &&
       node.workorder.rfcCi.ciBaseAttributes.hijackable_full_aliases == 'true'
-      delete_record('txt-' + dns_name,"hijackable_from_#{node.customer_domain}")
+      delete_record('txt-' + dns_name,"hijackable_from_#{get_customer_domain}")
     end
   end
     

--- a/packs/base.rb
+++ b/packs/base.rb
@@ -541,6 +541,67 @@ resource "fqdn",
              }
            ]
       }'
+    },
+    'os_payload' => {
+     'description' => 'os_payload',
+     'definition' => '{
+       "returnObject": false,
+       "returnRelation": false,
+       "relationName": "base.RealizedAs",
+       "direction": "to",
+       "targetClassName": "manifest.oneops.1.Fqdn",
+       "relations": [
+         { "returnObject": false,
+           "returnRelation": false,
+           "relationName": "manifest.DependsOn",
+           "direction": "from",
+           "targetClassName": "manifest.oneops.1.Compute",
+           "relations": [
+                 { "returnObject": true,
+                   "returnRelation": false,
+                   "relationName": "manifest.DependsOn",
+                   "direction": "to",
+                   "targetClassName": "manifest.oneops.1.Os"
+                 }
+            ]
+         }
+       ]
+     }'
+   },
+   'windowsdomain' => {
+       'description' => 'Windows-domain service',
+       'definition' => '{
+           "returnObject": false,
+           "returnRelation": false,
+           "relationName": "base.RealizedAs",
+           "direction": "to",
+           "targetClassName": "manifest.oneops.1.Fqdn",
+           "relations": [
+             { "returnObject": false,
+               "returnRelation": false,
+               "relationName": "manifest.Requires",
+               "direction": "to",
+               "targetClassName": "manifest.Platform",
+               "relations": [
+                 { "returnObject": false,
+                   "returnRelation": false,
+                   "relationName": "base.Consumes",
+                   "direction": "from",
+                   "targetClassName": "account.Cloud",
+                   "relations": [
+                     { "returnObject": true,
+                       "returnRelation": false,
+                       "relationName": "base.Provides",
+                       "relationAttrs":[{"attributeName":"service", "condition":"eq", "avalue":"windows-domain"}],
+                       "direction": "from",
+                       "targetClassName": "cloud.service.Windows-domain"
+                     }
+                   ]
+                 }
+               ]
+             }
+           ]
+      }'
     }
   }
 
@@ -720,10 +781,10 @@ resource "certificate",
                     'days_remaining'   => metric( :unit => 'count', :description => 'Days remaining to Expiry', :dstype => 'GAUGE')
                   },
                   :thresholds => {
-			  'cert-expiring-soon' => threshold('1m','avg','days_remaining',trigger('<=',30,1,1),reset('>',90,1,1))
+                    'cert-expiring-soon' => threshold('1m','avg','days_remaining',trigger('<=',30,1,1),reset('>',90,1,1))
                   }
                 }
-        }	 
+        }
 
 
 resource "hostname",
@@ -733,8 +794,44 @@ resource "hostname",
     :constraint => "0..1",
     :services => "dns",
     :help => "optional hostname dns entry"
+  },
+  :payloads => {
+   'windowsdomain' => {
+       'description' => 'Windows-domain service',
+       'definition' => '{
+           "returnObject": false,
+           "returnRelation": false,
+           "relationName": "base.RealizedAs",
+           "direction": "to",
+           "targetClassName": "manifest.oneops.1.Fqdn",
+           "relations": [
+             { "returnObject": false,
+               "returnRelation": false,
+               "relationName": "manifest.Requires",
+               "direction": "to",
+               "targetClassName": "manifest.Platform",
+               "relations": [
+                 { "returnObject": false,
+                   "returnRelation": false,
+                   "relationName": "base.Consumes",
+                   "direction": "from",
+                   "targetClassName": "account.Cloud",
+                   "relations": [
+                     { "returnObject": true,
+                       "returnRelation": false,
+                       "relationName": "base.Provides",
+                       "relationAttrs":[{"attributeName":"service", "condition":"eq", "avalue":"windows-domain"}],
+                       "direction": "from",
+                       "targetClassName": "cloud.service.Windows-domain"
+                     }
+                   ]
+                 }
+               ]
+             }
+           ]
+      }'
+    }
   }
-
 resource "sensuclient",
    :cookbook => "oneops.1.sensuclient",
    :design => true,


### PR DESCRIPTION
Modifying fqdn to utilize zone subservices over the default dns service if the selection criteria are met.
Use domain suffix from windows-domain service for Windows VMs so Active directory name for a windows VM (cluster) matches its DNS name.