### PR TITLE
Don't merge: attaching azuredisk in storage recipe

### DIFF
--- a/components/cookbooks/storage/recipes/add.rb
+++ b/components/cookbooks/storage/recipes/add.rb
@@ -218,6 +218,8 @@ Array(1..slice_count).each do |i|
     vols.push(volume.to_s+":"+dev)
     node.set["device_map"] = vols.join(" ")
     include_recipe "azuredatadisk::add" #Create datadisk, but doesn't attach it to the compute
+    Chef::Log.info("Attaching storage to compute")
+    include_recipe "azuredatadisk::attach"
   else
     Chef::Log.info("added "+volume.id.to_s)
     vols.push(volume.id.to_s+":"+dev)


### PR DESCRIPTION
In oneops circuit, storage and compute are created at inductor and at volume recipe, storage is attached and mount is created. This is possible because compute is having chef 11.18.12 and has azure gems installed on it.
In oneops circuit, storage and compute are created at inductor and at volume recipe, storage at inductor itself and compute doesn’t support azure gems.
Now problem is arises when circuit mian/walmartlabs started calling storage from oneops circuit for azure. Storage is getting created at inductor but not getting attached to compute but volume trying to create volume considering its already attached and failing saying that device not found.
For workaround, attaching storage at inductor itself rather than in volume recipe.