### PR TITLE
failure on persistent volume on touch if mentioned in percentage

### DIFF
--- a/components/cookbooks/volume/recipes/add.rb
+++ b/components/cookbooks/volume/recipes/add.rb
@@ -661,7 +661,9 @@ ruby_block 'create-storage-non-ephemeral-volume' do
       end
 
       #will not run if there is no change in updated volume size
-      if size != "0G"
+      if (size == "0G" || ((!storageUpdated) && size =~ /%/))
+        Chef::Log.info("Storage is not extended")
+      else
         execute_command("yes |lvextend #{l_switch} +#{size} /dev/#{platform_name}/#{logical_name}")
       end
 


### PR DESCRIPTION
When volume is defined in percentage and used fully, if user touch volume component and deploy, it's failing. Touch should check if storage is updated, if yes then only it should run extend query.