### PR TITLE
Fixing a bug in compute replace - it is calling fqdn recipe which in …

### DIFF
--- a/components/cookbooks/compute/metadata.rb
+++ b/components/cookbooks/compute/metadata.rb
@@ -5,6 +5,7 @@ maintainer_email "support@oneops.com"
 license          "Apache License, Version 2.0"
 depends          "azure"
 depends          "shared"
+depends          "fqdn"
 
 grouping 'default',
   :access => "global",


### PR DESCRIPTION
…its turn uses a function from the library

to get that library available in compute, the compute cookbook has to depend on fqdn one.