### PR TITLE
Fix issue where DC DNS not been deleted because of infoblox not following DNS spec by ignoring case sensitivity.

### DIFF
--- a/components/cookbooks/fqdn/recipes/delete.rb
+++ b/components/cookbooks/fqdn/recipes/delete.rb
@@ -63,6 +63,7 @@ if env.has_key?("global_dns") && env["global_dns"] == "true" &&
     include_recipe "azuretrafficmanager::delete"
   else
     include_recipe "netscaler::get_gslb_domain"
+    include_recipe "netscaler::get_dc_lbvserver"
     include_recipe "netscaler::delete_gslb_service"
     include_recipe "netscaler::delete_gslb_vserver"
     include_recipe "netscaler::logout"

--- a/components/cookbooks/fqdn/recipes/set_dns_entries_infoblox.rb
+++ b/components/cookbooks/fqdn/recipes/set_dns_entries_infoblox.rb
@@ -191,8 +191,15 @@ node[:entries].each do |entry|
 
          delete_record(dns_name, existing_entry)
       end
-    end
 
+      # First check to make sure we have dc_entry attribute
+      if node[:dc_entry] 
+        if dns_name.downcase.eql?(node[:dc_entry][:name].downcase)
+          # Delete existing entry only if it's not dc_entry (active dc_entry)
+          delete_dns(dns_name, existing_entry) if !node[:dc_entry][:values].include?(existing_entry)
+        end
+      end
+    end
   end
 
   # delete workorder skips the create call

--- a/components/cookbooks/fqdn/recipes/set_dns_entries_infoblox.rb
+++ b/components/cookbooks/fqdn/recipes/set_dns_entries_infoblox.rb
@@ -218,7 +218,7 @@ node[:entries].each do |entry|
     end
     
     record = {
-       :name => dns_name,
+       :name => dns_name.downcase,
        :view => view_attribute,
        :ttl => ttl
     }


### PR DESCRIPTION
Need to call "netscaler::get_dc_lbvserver" as it set the following attributes which are critical for them to tag for delete.

1.  dc_vip
2.  dc_entry