### PR TITLE
Don't merge: Azuredisk attach onupdate

### DIFF
--- a/components/cookbooks/storage/recipes/update.rb
+++ b/components/cookbooks/storage/recipes/update.rb
@@ -12,6 +12,8 @@ else
   Chef::Log.info("device map not nil")
   if storage_provider =~ /cinder/
     include_recipe 'storage::add'
+  elsif storage_provider =~ /azure/
+    include_recipe "azuredatadisk::attach"
   else
     Chef::Log.info("Storage volume extension not supported")
   end


### PR DESCRIPTION
Check if storage_provider is azure and if it is, it will attach storage to compute. This is helpful for main and labs circuit as storage can't be attached on compute.