### PR TITLE
Spark log file maintenance

### DIFF
--- a/components/cookbooks/spark-v1/templates/default/check_spark_log.sh.erb
+++ b/components/cookbooks/spark-v1/templates/default/check_spark_log.sh.erb
@@ -7,7 +7,8 @@
 #!/usr/bin/env bash
 
 # Look up the spark log based on the log parameter
-LOG_PATTERN="<%= @spark_log_dir %>/spark-spark-*$2*.out"
+#LOG_PATTERN="<%= @spark_log_dir %>/spark-spark-*$2*.out"
+LOG_PATTERN="<%= @spark_log_dir %>/spark-*$2*.log"
 LOG_FILE=`ls -1 $LOG_PATTERN |head -n 1`
 
 /opt/nagios/libexec/check_logfiles   --noprotocol --tag=$1 --logfile=$LOG_FILE --warningpattern="$3" --criticalpattern="$4"

--- a/components/cookbooks/spark-v1/templates/default/log4j-daemon.properties.erb
+++ b/components/cookbooks/spark-v1/templates/default/log4j-daemon.properties.erb
@@ -4,14 +4,11 @@
   # This is the log4j configuration that is used for Spark services
   # on all nodes.
  %>
-<%
+# Specify the default log file.  This is overridden for the master and worker.
+spark.log.file=/tmp/spark-${user.name}.log
+
 # Set everything to be logged to the console
 #log4j.rootCategory=INFO, console
-%>
-# Specify the default log file.  This is overridden for the master and worker.
-spark.log.file=<%= @log_dir %>/spark-${user.name}.log
-
-# Send all log information to a file
 log4j.rootCategory=INFO, RFA
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
@@ -33,10 +30,6 @@ log4j.appender.RFA.immediateFlush=true
 log4j.appender.RFA.append=true
 log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
 log4j.appender.RFA.layout.conversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
-
-# Turn off info logging for SparkContext. This allows the progress bar to show up
-# on the command line.
-log4j.logger.org.apache.spark.SparkContext=WARN
 
 # Set the default spark-shell log level to WARN. When running the spark-shell, the
 # log level for this class is used to overwrite the root logger's log level, so that

--- a/components/cookbooks/spark-v1/templates/default/spark-env.sh.erb
+++ b/components/cookbooks/spark-v1/templates/default/spark-env.sh.erb
@@ -41,7 +41,10 @@ export HADOOP_CONF_DIR=<%= @hadoop_dir %>/etc/hadoop
 # The log4j configuration is shared across all components.
 LOG4J="-Dlog4j.configuration=file://$SPARK_CONF_DIR/log4j.properties"
 
-export SPARK_MASTER_OPTS=" $LOG4J -Dspark.log.file=<%= @spark_tmp_dir %>/logs/spark-master.log "
+# The log4j configuration shared across all daemons.
+LOG4J_DAEMON="-Dlog4j.configuration=file://$SPARK_CONF_DIR/log4j-daemon.properties"
+
+export SPARK_MASTER_OPTS=" $LOG4J_DAEMON -Dspark.log.file=<%= @spark_tmp_dir %>/logs/spark-master.log "
 
 # Add user-specified master options
 <% if configNode['master_opts'] != nil && configNode['master_opts'].size > 0 %>	
@@ -51,7 +54,7 @@ SPARK_MASTER_OPTS="$SPARK_MASTER_OPTS <%= opt %>"
 export SPARK_MASTER_OPTS
 <% end %>
 
-export SPARK_WORKER_OPTS=" $LOG4J -Dspark.log.file=<%= @spark_tmp_dir %>/logs/spark-worker.log "
+export SPARK_WORKER_OPTS=" $LOG4J_DAEMON -Dspark.log.file=<%= @spark_tmp_dir %>/logs/spark-worker.log "
 
 # Add user-specified worker options
 <% if configNode['worker_opts'] != nil && configNode['worker_opts'].size > 0 %>	
@@ -61,7 +64,7 @@ SPARK_WORKER_OPTS="$SPARK_WORKER_OPTS <%= opt %>"
 export SPARK_WORKER_OPTS
 <% end %>
 
-export SPARK_HISTORY_OPTS=" $LOG4J -Dspark.log.file=<%= @spark_tmp_dir %>/logs/spark-history.log "
+export SPARK_HISTORY_OPTS=" $LOG4J_DAEMON -Dspark.log.file=<%= @spark_tmp_dir %>/logs/spark-history.log "
 
 <%
   # Executor option defaults are not configurable at the server and


### PR DESCRIPTION
Change the Spark log files to be placed under /work, and use a rolling file appender to control the size of them.