### PR TITLE
Fixed RVM install of ruby-2.3.3

### DIFF
--- a/components/cookbooks/ruby/recipes/rvm.rb
+++ b/components/cookbooks/ruby/recipes/rvm.rb
@@ -83,8 +83,13 @@ end
 # install ruby
 bash "install ruby-#{version}" do
   code <<-EOH
+if [ -f ~/.bash_profile ]; then
+  source ~/.bash_profile
+fi
 source /etc/profile.d/rvm.sh
 rvm mount -r #{ruby_binary} --verify-downloads 2
+cd #{src_dir}/rvm
+./install --auto-dotfiles
 rvm use #{version} --default
 EOH
 end


### PR DESCRIPTION
Fixed existing logic to source the current user profile such that rvm can
perform its magic.  Also perform temporary workaround the issue of complaining
about missing library even when the library is present on the system. By
running install --auto-dotfiles rvm fixed environments along with gemsets.