### PR TITLE
Set Nio Connector as default in tomcat pack

### DIFF
--- a/components/cookbooks/tomcat/metadata.rb
+++ b/components/cookbooks/tomcat/metadata.rb
@@ -80,10 +80,10 @@ attribute 'protocol',
           :required => 'required',
           :default => 'Non blocking Java connector',
           :format => {
-              :help => 'Sets "protocol" attribute in server.xml connector.[Blocking Java connector=org.apache.coyote.http11.Http11Protocol,Non blocking Java connector=org.apache.coyote.http11.Http11NioProtocol,The APR/native connector=org.apache.coyote.http11.Http11AprProtocol]. Refer. /tomcat-7.0-doc/config/http.html ',
+              :help => 'Sets "protocol" attribute in server.xml connector.[Blocking Java connector=org.apache.coyote.http11.Http11Protocol,Non blocking Java connector=org.apache.coyote.http11.Http11NioProtocol]. Refer. /tomcat-7.0-doc/config/http.html ',
               :category => '2.Server',
               :order => 3,
-              :form => {'field' => 'select', 'options_for_select' => [['HTTP/1.1 - Deprecated','HTTP/1.1'],['Blocking Java connector', 'org.apache.coyote.http11.Http11Protocol'], ['Non blocking Java connector', 'org.apache.coyote.http11.Http11NioProtocol']]},
+              :form => {'field' => 'select', 'options_for_select' => [['Non blocking Java connector','org.apache.coyote.http11.Http11NioProtocol'],['Blocking Java connector', 'org.apache.coyote.http11.Http11Protocol']]},
           }
 
 attribute 'http_connector_enabled',


### PR DESCRIPTION
Made the change to have the Nio connector as default choice in the tomcat pack. Also removed the deprecated controller from the list.