### PR TITLE
continuous integration in build component

### DIFF
--- a/components/cookbooks/build/.kitchen.yml
+++ b/components/cookbooks/build/.kitchen.yml
@@ -154,3 +154,53 @@ suites:
             repository: "https://github.com/oneops/oneops.git"
             revision: "master"
             install_dir: "/opt/build"
+  - name: contineousBuild
+    run_list:
+      - recipe[kitchen-test-helper]
+      - recipe[build::add]
+    attributes:
+      customer_domain: ""
+      build:
+        migration_command: ""
+        install_dir: "/opt/build"
+        ci: "true"
+        submodules: "false"
+        as_group: ""
+        before_migrate: ""
+        repository: "https://github.com/oneops/oneops.git"
+        revision: 'master'
+        environment: "{}"
+        password: ""
+        depth: "1"
+        as_user: ""
+        before_restart: ""
+        persist: "[]"
+        scm: "git"
+        key: ""
+        username: ""
+        restart_command: ""
+      workorder:
+        services:
+          mirror:
+            dummy:
+              ciAttributes:
+                mirrors: "{}"
+        cloud:
+          ciName: "dummy"
+        payLoad:
+          RealizedAs:
+            -
+              ciName: "build"
+        rfcCi:
+          nsPath: ""
+          ciAttributes:
+            key: ""
+            ci: "true"
+            persist : "[]"
+            environment: "{}"
+            migration_command: ""
+            depth: "1"
+            restart_command: ""
+            repository: "https://github.com/oneops/oneops.git"
+            revision: "master"
+          ciName: "dummy"

--- a/components/cookbooks/build/recipes/build_wrapper.rb
+++ b/components/cookbooks/build/recipes/build_wrapper.rb
@@ -192,18 +192,20 @@ build "#{install_dir}" do
 end
 
 if ci[:ciAttributes][:ci] == 'true'
+  `sudo cp /opt/oneops/workorder/build.#{ci[:ciName]}.json /opt/oneops/`
   cron "continuous_integration_#{manifest}" do
     minute "0,5,10,15,20,25,30,35,40,45,50,55"
     path '${PATH}:/usr/local/bin:/usr/bin'
-    command "chef-solo -l debug -c /home/oneops/cookbooks/chef.rb -j /opt/oneops/workorder/build.#{ci[:ciName]}.json >> /tmp/build.#{ci[:ciName]}.log 2>&1"
+    command "/usr/local/bin/chef-solo -l info -F doc -c /home/oneops/circuit-oneops-1/components/cookbooks/chef-build.#{ci[:ciName]}.rb -j /opt/oneops/build.#{ci[:ciName]}.json >> /tmp/build.#{ci[:ciName]}.log 2>&1"
     mailto '/dev/null'
     action :create
   end
 elsif ci[:ciAttributes][:ci] == 'false' && ci.has_key?(:ciBaseAttributes) && ci[:ciBaseAttributes][:ci] && ci[:ciBaseAttributes][:ci] == 'true'
+  `sudo rm /opt/oneops/build.#{ci[:ciName]}.json`
   cron "continuous_integration_#{manifest}" do
     minute "0,5,10,15,20,25,30,35,40,45,50,55"
     path '${PATH}:/usr/local/bin:/usr/bin'
-    command "chef-solo -l debug -c /home/oneops/cookbooks/chef.rb -j /opt/oneops/workorder/build.#{ci[:ciName]}.json >> /tmp/build.#{ci[:ciName]}.log 2>&1"
+    command "/usr/local/bin/chef-solo -l info -F doc -c /home/oneops/circuit-oneops-1/components/cookbooks/chef-build.#{ci[:ciName]}.rb -j /opt/oneops/build.#{ci[:ciName]}.json >> /tmp/build.#{ci[:ciName]}.log 2>&1"
     mailto '/dev/null'
     action :delete
   end

--- a/components/cookbooks/build/test/integration/contineousBuild/serverspec/contineous_spec.rb
+++ b/components/cookbooks/build/test/integration/contineousBuild/serverspec/contineous_spec.rb
@@ -1,0 +1,7 @@
+require 'serverspec'
+require 'pathname'
+require 'json'
+
+describe cron do
+  it { should have_entry "0,5,10,15,20,25,30,35,40,45,50,55 * * * * /usr/local/bin/chef-solo -l info -F doc -c /home/oneops/circuit-oneops-1/components/cookbooks/chef-build.dummy.rb -j /opt/oneops/build.dummy.json >> /tmp/build.dummy.log 2>&1" }
+end

--- a/components/cookbooks/build/test/integration/contineousBuild/serverspec/spec_helper.rb
+++ b/components/cookbooks/build/test/integration/contineousBuild/serverspec/spec_helper.rb
@@ -1,0 +1,15 @@
+require 'serverspec'
+require 'pathname'
+require 'json'
+
+if ENV['OS'] == 'Windows_NT'
+  set :backend, :cmd
+  # On Windows, set the target host's OS explicitly
+  set :os, :family => 'windows'
+  $node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))
+else
+  set :backend, :exec
+  $node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+end
+
+set :path, '/sbin:/usr/local/sbin:/usr/sbin:$PATH' unless os[:family] == 'windows'


### PR DESCRIPTION
Work-order was not retaining after setting cronjob, because of that though the cronjob was setting, it was failing. Now required work-order is copied to another location and set cronjob accordingly.