### PR TITLE
reverting confiz's changes to metadata.rb for several cookbooks

### DIFF
--- a/components/cookbooks/azure/metadata.rb
+++ b/components/cookbooks/azure/metadata.rb
@@ -1,4 +1,4 @@
-name 'azure'
+name 'Azure'
 description 'Azure Cloud Service'
 version '0.1'
 maintainer 'OneOps'

--- a/components/cookbooks/azure_base/metadata.rb
+++ b/components/cookbooks/azure_base/metadata.rb
@@ -1,4 +1,4 @@
-name             'azure_base'
+name             'Azure_base'
 maintainer       'OneOps'
 maintainer_email 'support@oneops.com'
 license          'Apache License, Version 2.0'

--- a/components/cookbooks/azure_lb/metadata.rb
+++ b/components/cookbooks/azure_lb/metadata.rb
@@ -1,4 +1,4 @@
-name             'azure_lb'
+name             'Azure_lb'
 description      'Azure Load Balancer'
 version          '0.1.0'
 maintainer       'OneOps'

--- a/components/cookbooks/azuredatadisk/metadata.rb
+++ b/components/cookbooks/azuredatadisk/metadata.rb
@@ -1,4 +1,4 @@
-name             'azuredatadisk'
+name             'Azuredatadisk'
 maintainer       'walmart'
 maintainer_email 'kowsalya.palaniappan@walmart.com'
 license          'Apache License, Version 2.0'

--- a/components/cookbooks/azuredns/metadata.rb
+++ b/components/cookbooks/azuredns/metadata.rb
@@ -1,4 +1,4 @@
-name             'azuredns'
+name             'Azuredns'
 maintainer       'oneops'
 maintainer_email 'support@oneops.com'
 license          'Apache License, Version 2.0'

--- a/components/cookbooks/azuregateway/metadata.rb
+++ b/components/cookbooks/azuregateway/metadata.rb
@@ -1,4 +1,4 @@
-name 'azuregateway'
+name 'Azuregateway'
 description 'Azure Application Gateway'
 version '0.1.0'
 maintainer 'OneOps'

--- a/components/cookbooks/azurekeypair/metadata.rb
+++ b/components/cookbooks/azurekeypair/metadata.rb
@@ -1,4 +1,4 @@
-name 'azurekeypair'
+name 'Azure Keypair'
 description 'General purpose key pairs'
 version '0.1'
 maintainer 'OneOps, Inc.'
@@ -8,19 +8,20 @@ license 'Apache License, Version 2.0'
 depends 'azure_base'
 
 grouping 'default',
-         access: 'global',
-         packages: ['base', 'account', 'mgmt.catalog', 'mgmt.manifest', 'catalog', 'manifest']
+         :access => "global",
+         :packages => [ 'base', 'account', 'mgmt.catalog', 'mgmt.manifest', 'catalog', 'manifest' ]
 
 grouping 'bom',
-         access: 'global',
-         packages: ['bom']
+         :access => "global",
+         :packages => [ 'bom' ]
+
 
 attribute 'key_name',
-          description: 'Key Name',
-          grouping: 'bom',
-          data_type: 'text',
-          format: {
-            help: 'Key-Name value pair',
-            category: '1.Global',
-            order: 6
+          :description => "Key Name",
+          :grouping => 'bom',
+          :data_type => "text",
+          :format => {
+              :help => 'Key-Name value pair',
+              :category => '1.Global',
+              :order => 6
           }

--- a/components/cookbooks/azuresecgroup/metadata.rb
+++ b/components/cookbooks/azuresecgroup/metadata.rb
@@ -7,9 +7,9 @@ license 'Apache License, Version 2.0'
 depends 'azure'
 
 grouping 'default',
-         access: 'global',
-         packages: ['base', 'account', 'mgmt.catalog', 'mgmt.manifest', 'catalog', 'manifest']
+         :access => "global",
+         :packages => [ 'base', 'account', 'mgmt.catalog', 'mgmt.manifest', 'catalog', 'manifest' ]
 
 grouping 'bom',
-         access: 'global',
-         packages: ['bom']
+         :access => "global",
+         :packages => [ 'bom' ]

--- a/components/cookbooks/azuretrafficmanager/metadata.rb
+++ b/components/cookbooks/azuretrafficmanager/metadata.rb
@@ -1,4 +1,4 @@
-name             'azuretrafficmanager'
+name             'Azuretrafficmanager'
 description      'Installs/Configures trafficmanager'
 version          '0.1.0'
 maintainer       'OneOps'

--- a/components/cookbooks/compute/metadata.rb
+++ b/components/cookbooks/compute/metadata.rb
@@ -1,4 +1,4 @@
-name             "compute"
+name             "Compute"
 description      "Installs/Configures compute"
 maintainer       "OneOps"
 maintainer_email "support@oneops.com"

--- a/components/cookbooks/f5-bigip/metadata.rb
+++ b/components/cookbooks/f5-bigip/metadata.rb
@@ -1,4 +1,4 @@
-name             "f5-bigip"
+name             "F5-bigip"
 description      "F5 BigIP"
 version          "0.1"
 maintainer       "OneOps"

--- a/components/cookbooks/fqdn/metadata.rb
+++ b/components/cookbooks/fqdn/metadata.rb
@@ -1,4 +1,4 @@
-name             "fqdn"
+name             "Fqdn"
 description      "Updates FQDN records"
 version          "0.1"
 maintainer       "OneOps"

--- a/components/cookbooks/haproxy/metadata.rb
+++ b/components/cookbooks/haproxy/metadata.rb
@@ -1,4 +1,4 @@
-name             "haproxy"
+name             "Haproxy"
 description      "HA Proxy"
 version          "0.1"
 maintainer       "OneOps"

--- a/components/cookbooks/keypair/metadata.rb
+++ b/components/cookbooks/keypair/metadata.rb
@@ -1,4 +1,4 @@
-name             "keypair"
+name             "Keypair"
 description      "General purpose key pairs"
 version          "0.1"
 maintainer       "OneOps, Inc."

--- a/components/cookbooks/lb/metadata.rb
+++ b/components/cookbooks/lb/metadata.rb
@@ -1,4 +1,4 @@
-name             "lb"
+name             "Lb"
 description      "Installs/Configures load balancer"
 version          "0.1"
 maintainer       "OneOps"

--- a/components/cookbooks/netscaler/metadata.rb
+++ b/components/cookbooks/netscaler/metadata.rb
@@ -1,4 +1,4 @@
-name             "netscaler"
+name             "Netscaler"
 description      "Netscaler"
 version          "0.1"
 maintainer       "OneOps"

--- a/components/cookbooks/os/metadata.rb
+++ b/components/cookbooks/os/metadata.rb
@@ -1,4 +1,4 @@
-name "os"
+name "Os"
 description "Installs/Configures OperatingSystem"
 maintainer "OneOps"
 maintainer_email "support@oneops.com"

--- a/components/cookbooks/secgroup/metadata.rb
+++ b/components/cookbooks/secgroup/metadata.rb
@@ -1,4 +1,4 @@
-name             "secgroup"
+name             "Secgroup"
 description      "Security group"
 version          "0.1"
 maintainer       "OneOps, Inc."

--- a/components/cookbooks/storage/metadata.rb
+++ b/components/cookbooks/storage/metadata.rb
@@ -1,4 +1,4 @@
-name             "storage"
+name             "Storage"
 description      "Storage"
 version          "0.1"
 maintainer       "OneOps"

--- a/components/cookbooks/volume/metadata.rb
+++ b/components/cookbooks/volume/metadata.rb
@@ -1,4 +1,4 @@
-name             "volume"
+name             "Volume"
 description      "Volume"
 version          "0.1"
 maintainer       "OneOps"


### PR DESCRIPTION
Confiz team had to change the `name` attribute in `metadata.rb` of several cookbooks to make them work with chef-12.0.0. Since we are not migrating to chef-12 now, I am reverting these changes to what they used to be before the change