### PR TITLE
calling gdns service for azure on basis of cloud priority

### DIFF
--- a/components/cookbooks/fqdn/recipes/add.rb
+++ b/components/cookbooks/fqdn/recipes/add.rb
@@ -64,11 +64,26 @@ end
 Chef::Log.info("Depends on LB is: #{depends_on_lb}")
 if env.has_key?("global_dns") && env["global_dns"] == "true" && depends_on_lb &&
    !gdns_service.nil? && gdns_service["ciAttributes"]["gslb_authoritative_servers"] != '[]'
-   if provider !~ /azuredns/
+  if provider !~ /azuredns/
+    if cloud_name =~ /azure/
+      if node[:workorder][:cloud][:ciAttributes][:priority] == "1"
+        include_recipe "netscaler::get_dc_lbvserver"
+        include_recipe "netscaler::add_gslb_vserver"
+        include_recipe "netscaler::add_gslb_service"
+        include_recipe "netscaler::logout"
+      else
+        include_recipe "netscaler::get_gslb_domain"
+        include_recipe "netscaler::get_dc_lbvserver"
+        include_recipe "netscaler::delete_gslb_service"
+        include_recipe "netscaler::delete_gslb_vserver"
+        include_recipe "netscaler::logout"
+      end
+    else
       include_recipe "netscaler::get_dc_lbvserver"
       include_recipe "netscaler::add_gslb_vserver"
       include_recipe "netscaler::add_gslb_service"
       include_recipe "netscaler::logout"
+    end
   end
 end
 


### PR DESCRIPTION
GDNS service will now get called on cloud priority basis and if cloud priority is changed to secondary, we are unbinding gdns for that cloud. No code change for open-stack.