### PR TITLE
azure - lb, ecv & resource tagging changes

### DIFF
--- a/components/cookbooks/azure/libraries/network_interface_card.rb
+++ b/components/cookbooks/azure/libraries/network_interface_card.rb
@@ -9,7 +9,7 @@ require 'ipaddr'
 module AzureNetwork
   # class to implement all functionality needed for an Azure NIC.
   class NetworkInterfaceCard
-    attr_accessor :location, :rg_name, :private_ip, :profile, :ci_id, :network_client, :publicip, :subnet_cls, :virtual_network, :nsg, :flag
+    attr_accessor :location, :rg_name, :private_ip, :profile, :ci_id, :network_client, :publicip, :subnet_cls, :virtual_network, :nsg, :flag, :tags
     attr_reader :creds, :subscription
 
     def initialize(creds)
@@ -50,6 +50,7 @@ module AzureNetwork
       network_interface.ip_configuration_name = nic_ip_config.name
       network_interface.subnet_id = nic_ip_config.subnet_id
       network_interface.public_ip_address_id = nic_ip_config.public_ipaddress_id
+      network_interface.tags = @tags
 
       OOLog.info("Network Interface name is: #{network_interface.name}")
       network_interface
@@ -89,7 +90,8 @@ module AzureNetwork
                                                                ip_configuration_name: network_interface.ip_configuration_name,
                                                                private_ip_allocation_method: network_interface.private_ip_allocation_method,
                                                                load_balancer_backend_address_pools_ids: network_interface.load_balancer_backend_address_pools_ids,
-                                                               load_balancer_inbound_nat_rules_ids: network_interface.load_balancer_inbound_nat_rules_ids)
+                                                               load_balancer_inbound_nat_rules_ids: network_interface.load_balancer_inbound_nat_rules_ids,
+                                                               tags: network_interface.tags)
         end
 
         end_time = Time.now.to_i

--- a/components/cookbooks/azure/libraries/virtual_machine_manager.rb
+++ b/components/cookbooks/azure/libraries/virtual_machine_manager.rb
@@ -12,7 +12,8 @@ module AzureCompute
                   :storage_profile,
                   :network_profile,
                   :virtual_machine_lib,
-                  :availability_set_response
+                  :availability_set_response,
+                  :tags
 
     def initialize(node)
       @cloud_name = node['workorder']['cloud']['ciName']
@@ -30,6 +31,7 @@ module AzureCompute
       @platform = @compute_service[:ostype].include?('windows') ? 'windows' : 'linux'
       @platform_ci_id = node['workorder']['box']['ciId']
       @compute_ci_id = node['workorder']['rfcCi']['ciId']
+      @tags = {}
 
       @creds = {
           tenant_id: @compute_service[:tenant_id],
@@ -69,11 +71,13 @@ module AzureCompute
       @network_profile.location = @location
       @network_profile.rg_name = @resource_group_name
       @network_profile.ci_id = @compute_ci_id
+      @network_profile.tags = @tags
       # build hash containing vm info
       # used in Fog::Compute::AzureRM::create_virtual_machine()
       vm_hash = {}
 
       # common values
+      vm_hash[:tags] = @tags
       vm_hash[:name] = @server_name
       vm_hash[:resource_group] = @resource_group_name
 

--- a/components/cookbooks/azure/recipes/add_node.rb
+++ b/components/cookbooks/azure/recipes/add_node.rb
@@ -8,7 +8,13 @@ Utils.set_proxy(node['workorder']['payLoad']['OO_CLOUD_VARS'])
 # get platform resource group and availability set
 include_recipe 'azure::get_platform_rg_and_as'
 
+tags = Utils.get_resource_tags(node)
+
+OOLog.info("tags are: #{tags.inspect}")
+
 vm_manager = AzureCompute::VirtualMachineManager.new(node)
+vm_manager.tags = tags
+
 compute_service = vm_manager.compute_service
 
 credentials = {

--- a/components/cookbooks/azure_base/spec/resource_tags_spec.rb
+++ b/components/cookbooks/azure_base/spec/resource_tags_spec.rb
@@ -1,0 +1,44 @@
+require File.expand_path('../../libraries/utils.rb', __FILE__)
+require 'json'
+
+describe 'tags for resource' do
+
+  it 'contains Organization tags from workorder' do
+    wo = File.expand_path('workorders/workorder.json', File.dirname(__FILE__))
+    node = JSON.parse(File.read(wo))
+
+    tags = Utils.get_resource_tags(node)
+    expect(tags).to include("tag1")
+    expect(tags).to include("tag2")
+
+  end
+
+  it 'contains Assembly tags from workorder' do
+    wo = File.expand_path('workorders/workorder.json', File.dirname(__FILE__))
+    node = JSON.parse(File.read(wo))
+
+    tags = Utils.get_resource_tags(node)
+    expect(tags).to include("tag3")
+    expect(tags).to include("tag1")
+
+  end
+
+  it 'overrides Organization tags with Assembly tags when same name is used' do
+    wo = File.expand_path('workorders/workorder.json', File.dirname(__FILE__))
+    node = JSON.parse(File.read(wo))
+
+    tags = Utils.get_resource_tags(node)
+    expect(tags).to include("tag1" => "from assembly")
+    expect(tags).to include("tag2")
+    expect(tags).to include("tag3")
+
+  end
+
+  it 'has tag named owner' do
+    wo = File.expand_path('workorders/workorder.json', File.dirname(__FILE__))
+    node = JSON.parse(File.read(wo))
+
+    tags = Utils.get_resource_tags(node)
+    expect(tags).to include('owner')
+  end
+end

--- a/components/cookbooks/azure_lb/libraries/load_balancer.rb
+++ b/components/cookbooks/azure_lb/libraries/load_balancer.rb
@@ -167,7 +167,7 @@ module AzureNetwork
       }
     end
 
-    def self.get_lb(resource_group_name, lb_name, location, frontend_ip_configs, backend_address_pools, lb_rules, nat_rules, probes)
+    def self.get_lb(resource_group_name, lb_name, location, frontend_ip_configs, backend_address_pools, lb_rules, nat_rules, probes, tags)
       {
           name: lb_name,
           resource_group: resource_group_name,
@@ -176,7 +176,8 @@ module AzureNetwork
           backend_address_pool_names: backend_address_pools,
           load_balancing_rules: lb_rules,
           inbound_nat_rules: nat_rules,
-          probes: probes
+          probes: probes,
+          tags: tags
       }
     end
 

--- a/components/cookbooks/azure_lb/recipes/add.rb
+++ b/components/cookbooks/azure_lb/recipes/add.rb
@@ -283,7 +283,8 @@ nat_rules = []
 get_compute_nat_rules(frontend_ipconfig_id, nat_rules, compute_natrules)
 
 # Configure LB properties
-load_balancer = AzureNetwork::LoadBalancer.get_lb(resource_group_name, lb_name, location, frontend_ipconfigs, backend_address_pools, lb_rules, nat_rules, probes)
+tags = Utils.get_resource_tags(node)
+load_balancer = AzureNetwork::LoadBalancer.get_lb(resource_group_name, lb_name, location, frontend_ipconfigs, backend_address_pools, lb_rules, nat_rules, probes, tags)
 
 # Create LB
 lb_svc = AzureNetwork::LoadBalancer.new(creds)

--- a/components/cookbooks/azure_lb/spec/load_balancer_probe_spec.rb
+++ b/components/cookbooks/azure_lb/spec/load_balancer_probe_spec.rb
@@ -1,0 +1,185 @@
+require File.expand_path('../../libraries/load_balancer.rb', __FILE__)
+require 'json'
+
+describe 'valid probe for a listener' do
+
+  it 'uses probe with port matching backend port of listener' do
+    listener = {
+        name: "lname",
+        iport: 8080,
+        iprotocol: 'http',
+        vport: 'http',
+        vprotocol: 8080
+    }
+
+    probes = []
+    probes.push(
+        {
+            probe_name: "pname1",
+            interval_secs: 15,
+            num_probes: 3,
+            port: 8080,
+            protocol: 'http',
+            request_path: '/'
+        }
+    )
+    probes.push(
+        {
+            probe_name: "pname2",
+            interval_secs: 15,
+            num_probes: 3,
+            port: 8081,
+            protocol: 'http',
+            request_path: 'another_health_check'
+        }
+    )
+
+    found = AzureNetwork::LoadBalancer.get_probe_for_listener(listener, probes)
+    expect(found).not_to be_nil
+    expect(found[:probe_name]).to eq('pname1')
+    expect(found[:port].to_i).to eq(8080)
+
+  end
+
+  context 'for listener with http backend' do
+    it 'uses any http probe when no matching probe found' do
+      listener = {
+          name: "lname",
+          iport: 8080,
+          iprotocol: 'http',
+          vport: 'http',
+          vprotocol: 8080
+      }
+
+      probes = []
+      probes.push(
+          {
+              probe_name: "pname1",
+              interval_secs: 15,
+              num_probes: 3,
+              port: 8082,
+              protocol: 'http',
+              request_path: '/'
+          }
+      )
+      probes.push(
+          {
+              probe_name: "pname2",
+              interval_secs: 15,
+              num_probes: 3,
+              port: 8081,
+              protocol: 'Tcp',
+              request_path: 'nil'
+          }
+      )
+
+      found = AzureNetwork::LoadBalancer.get_probe_for_listener(listener, probes)
+      expect(found).not_to be_nil
+      expect(found[:probe_name]).to eq('pname1')
+      expect(found[:port].to_i).to eq(8082)
+
+    end
+
+    it 'returns nil when no matching probe and no http probe found' do
+      listener = {
+          name: "lname",
+          iport: 8080,
+          iprotocol: 'http',
+          vport: 'http',
+          vprotocol: 8080
+      }
+
+      probes = []
+      probes.push(
+          {
+              probe_name: "pname",
+              interval_secs: 15,
+              num_probes: 3,
+              port: 1234,
+              protocol: 'Tcp',
+              request_path: nil
+          }
+      )
+
+      found = AzureNetwork::LoadBalancer.get_probe_for_listener(listener, probes)
+      expect(found).to be_nil
+    end
+  end
+
+  context 'for listener with tcp backend' do
+    it 'creates a tcp probe when no matching probe found' do
+
+      #the workorder didnt have probe for the tcp listener
+      wo = File.expand_path('workorders/tcp_no_match.json', File.dirname(__FILE__))
+
+      node = JSON.parse(File.read(wo))
+      listener = JSON.parse(node['workorder']['rfcCi']['ciAttributes']['listeners'])[0]
+      listener_port = (listener.split(' ')[3]).to_i
+
+      probes = AzureNetwork::LoadBalancer.get_probes_from_wo(node)
+      found = probes.detect {|p| p[:port].to_i == listener_port}
+
+      expect(probes.length).to eq(2)
+
+      expect(found).not_to be_nil
+      expect(found[:protocol]).to eq('Tcp')
+      expect(found[:request_path]).to be_nil
+    end
+
+    it 'sets request path to nil on matching probe and uses it' do
+      wo = File.expand_path('workorders/tcp_match.json', File.dirname(__FILE__))
+
+      node = JSON.parse(File.read(wo))
+      listener = JSON.parse(node['workorder']['rfcCi']['ciAttributes']['listeners'])[0]
+      listener_port = (listener.split(' ')[3]).to_i
+
+      probes = AzureNetwork::LoadBalancer.get_probes_from_wo(node)
+      found = probes.detect {|p| p[:port].to_i == listener_port}
+
+      #when a match is found it is not creating a new one
+      expect(probes.length).to eq(1)
+
+      expect(found).not_to be_nil
+      expect(found[:port].to_i).to eq(listener_port)
+      expect(found[:request_path]).to be_nil
+    end
+  end
+
+  context 'for listener with https backend' do
+    it 'sets protocol on matching probe to Tcp and its request path to nil' do
+      wo = File.expand_path('workorders/https_match.json', File.dirname(__FILE__))
+
+      node = JSON.parse(File.read(wo))
+      listener = JSON.parse(node['workorder']['rfcCi']['ciAttributes']['listeners'])[0]
+      listener_port = (listener.split(' ')[3]).to_i
+
+      probes = AzureNetwork::LoadBalancer.get_probes_from_wo(node)
+      found = probes.detect {|p| p[:port].to_i == listener_port}
+
+      #when a match is found it is not creating a new one
+      expect(probes.length).to eq(1)
+
+      expect(found).not_to be_nil
+      expect(found[:port].to_i).to eq(listener_port)
+      expect(found[:request_path]).to be_nil
+    end
+
+    it 'creates tcp probe when no matching probe is found' do
+      wo = File.expand_path('workorders/https_no_match.json', File.dirname(__FILE__))
+
+      node = JSON.parse(File.read(wo))
+      listener = JSON.parse(node['workorder']['rfcCi']['ciAttributes']['listeners'])[0]
+      listener_port = (listener.split(' ')[3]).to_i
+
+      probes = AzureNetwork::LoadBalancer.get_probes_from_wo(node)
+      found = probes.detect {|p| p[:port].to_i == listener_port}
+
+      #when a match is not found a new probe is created.
+      expect(probes.length).to eq(2)
+
+      expect(found).not_to be_nil
+      expect(found[:port].to_i).to eq(listener_port)
+      expect(found[:request_path]).to be_nil
+    end
+  end
+end

--- a/components/cookbooks/azure_lb/spec/workorders/https_match.json
+++ b/components/cookbooks/azure_lb/spec/workorders/https_match.json
@@ -1,0 +1,14 @@
+{
+  "app_name": "lb",
+  "ip_attribute": "private_ip",
+  "name": "lb-96920452-1",
+  "workorder": {
+    "rfcCi": {
+      "ciAttributes": {
+        "listeners": "[\"http 80 https 8080\"]",
+        "ecv_map": "{\"8080\":\"GET health_check\"}"
+      }
+    }
+  },
+  "mgmt_domain": "stg.oneops.walmart.com"
+}

--- a/components/cookbooks/azure_lb/spec/workorders/https_no_match.json
+++ b/components/cookbooks/azure_lb/spec/workorders/https_no_match.json
@@ -1,0 +1,14 @@
+{
+  "app_name": "lb",
+  "ip_attribute": "private_ip",
+  "name": "lb-96920452-1",
+  "workorder": {
+    "rfcCi": {
+      "ciAttributes": {
+        "listeners": "[\"http 80 https 8080\"]",
+        "ecv_map": "{\"1234\":\"GET health_check\"}"
+      }
+    }
+  },
+  "mgmt_domain": "stg.oneops.walmart.com"
+}

--- a/components/cookbooks/azure_lb/spec/workorders/tcp_match.json
+++ b/components/cookbooks/azure_lb/spec/workorders/tcp_match.json
@@ -1,0 +1,14 @@
+{
+  "app_name": "lb",
+  "ip_attribute": "private_ip",
+  "name": "lb-96920452-1",
+  "workorder": {
+    "rfcCi": {
+      "ciAttributes": {
+        "listeners": "[\"http 80 tcp 5432\"]",
+        "ecv_map": "{\"5432\":\"GET health_check\"}"
+      }
+    }
+  },
+  "mgmt_domain": "stg.oneops.walmart.com"
+}

--- a/components/cookbooks/azure_lb/spec/workorders/tcp_no_match.json
+++ b/components/cookbooks/azure_lb/spec/workorders/tcp_no_match.json
@@ -1,0 +1,14 @@
+{
+  "app_name": "lb",
+  "ip_attribute": "private_ip",
+  "name": "lb-96920452-1",
+  "workorder": {
+    "rfcCi": {
+      "ciAttributes": {
+        "listeners": "[\"http 80 tcp 5432\"]",
+        "ecv_map": "{\"8080\":\"GET health_check\"}"
+      }
+    }
+  },
+  "mgmt_domain": "stg.oneops.walmart.com"
+}


### PR DESCRIPTION
`azure_lb/spec/load_balancer_probe_spec.rb` should be able to provide details on how a probe is identified for a given listener. 

and tags are added to azure resources when they are created. currently tags are added to `vm`, `nic`, `lb` resources. currently `fog-azure-rm` is not propagating vm tags to osDisk. when it is fixed whatever tags that are sent in vm creation should be added to osDisk also. 

`azure_base/spec/resource_tags_spec.rb` - should be able to identify the tags that are added to an azure resource