### PR TITLE
Add kitchen_proxy.rb to override existing behavior to support additional environment.

### DIFF
--- a/components/cookbooks/user/test/integration/add/serverspec/spec_helper.rb
+++ b/components/cookbooks/user/test/integration/add/serverspec/spec_helper.rb
@@ -9,7 +9,11 @@ if ENV['OS'] == 'Windows_NT'
   $node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))
 else
   set :backend, :exec
-  $node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+  if !ENV['WORKORDER'].empty?
+    $node = ::JSON.parse(File.read(ENV['WORKORDER'].to_s))
+  else
+    $node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+  end
 end
 
 set :path, '/sbin:/usr/local/sbin:/usr/sbin:$PATH' unless os[:family] == 'windows'

--- a/components/cookbooks/user/test/integration/delete/serverspec/spec_helper.rb
+++ b/components/cookbooks/user/test/integration/delete/serverspec/spec_helper.rb
@@ -9,7 +9,11 @@ if ENV['OS'] == 'Windows_NT'
   $node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))
 else
   set :backend, :exec
-  $node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+  if !ENV['WORKORDER'].empty?
+    $node = ::JSON.parse(File.read(ENV['WORKORDER'].to_s))
+  else
+    $node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+  end
 end
 
 set :path, '/sbin:/usr/local/sbin:/usr/sbin:$PATH' unless os[:family] == 'windows'

--- a/components/cookbooks/user/test/kitchen_proxy.rb
+++ b/components/cookbooks/user/test/kitchen_proxy.rb
@@ -1,0 +1,22 @@
+require "kitchen/verifier/busser"
+
+module Kitchen
+  module Verifier
+    class Busser < Kitchen::Verifier::Base
+      def busser_env
+        root = config[:root_path]
+        gem_home = gem_path = remote_path_join(root, "gems")
+        gem_cache = remote_path_join(gem_home, "cache")
+
+        [
+          shell_env_var("BUSSER_ROOT", root),
+          shell_env_var("GEM_HOME", gem_home),
+          shell_env_var("GEM_PATH", gem_path),
+          shell_env_var("GEM_CACHE", gem_cache),
+          shell_env_var("WORKORDER", ENV['WORKORDER'])
+        ].join("\n")
+          .tap { |str| str.insert(0, reload_ps1_path) if windows_os? }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add kitchen_proxy.rb to override existing behavior to add environment
variable WORKORDER to be used by tests.
Modify add/delete test spec_helper to use ENV['WORKORDER']