### PR TITLE
Run kitchen verify against localhost without going through ssh transport.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,14 @@
 source 'http://rubygems.org'
 
-gem 'oneops-admin', '1.0.0'
+ruby "=2.0.0"
 
-
+gem 'test-kitchen', '=1.16.0'
+gem 'berkshelf', '>= 4.3.5', '< 6.0.0'
+gem 'httpclient', '=2.7.2'
+gem 'json', '=1.8.6'
+gem 'public_suffix', '=2.0.5'
+gem 'mixlib-shellout', '=2.2.7'
+gem 'buff-extensions', '=1.0.0'
+gem 'nio4r', '=1.2.1'
+gem 'ridley', '=4.6.1'
+gem 'kitchen-vagrant', '=1.1.0'

--- a/README.md
+++ b/README.md
@@ -14,3 +14,48 @@ Knife
 =====
 
 For a single cookbook sync, use bundle exec knife model sync <cookbook-name>
+
+
+Test
+=====
+
+Local Verifier:
+
+```
+WORKORDER=<path_to_local_workorder> kitchen verify
+```
+
+```
+#<% load "#{File.dirname(__FILE__)}/../../../monkey_patch.rb" %>
+driver:
+  name: proxy
+  host: 127.0.0.1
+  reset_command: "exit 0"
+  port: 22
+  transport: local
+verifier:
+  name: busser
+  transport: local
+  sudo: false
+  busser_bin: busser
+  gem_home: /opt/oneops/inductor/kitchenci/verifier/gems
+  gem_path: /opt/oneops/inductor/kitchenci/verifier/gems
+  gem_cache: /opt/oneops/inductor/kitchenci/verifier/gems/cache
+```
+
+Remote Verifier:
+
+```
+WORKORDER=<path_to_workorder_on_remote_host> kitchen verify
+```
+
+```
+#<% load "#{File.dirname(__FILE__)}/../../../monkey_patch.rb" %>
+driver:
+  name: proxy
+  host: <%= compute %>
+  reset_command: "exit 0"
+  port: 22
+  username: local
+  ssh_key: <%= path to private key %>
+```


### PR DESCRIPTION
Override existing KitchenCi to run verifier on localhost without going through ssh transport.

Roll all existing features into single monkey_patch.rb to be included
at the top of each .kitchen.yml.