### PR TITLE
Adding Azure Security Group Test Cases

### DIFF
--- a/components/cookbooks/azure_base/test/integration/azure_spec_utils.rb
+++ b/components/cookbooks/azure_base/test/integration/azure_spec_utils.rb
@@ -125,4 +125,34 @@ class AzureSpecUtils
 
     lb_name
   end
+  def get_azure_rule_definition(resource_group_name, network_security_group_name, rules, node)
+    sec_rules = []
+    priority = 100
+    reg_ex = /(\d+|\*|\d+-\d+)\s(\d+|\*|\d+-\d+)\s([A-Za-z]+|\*)\s\S+/
+    rules.each do |item|
+      raise "#{item} is not a valid security rule" unless reg_ex.match(item)
+      item2 = item.split(' ')
+      security_rule_access = Fog::ARM::Network::Models::SecurityRuleAccess::Allow
+      security_rule_description = node['secgroup']['description']
+      security_rule_source_addres_prefix = item2[3]
+      security_rule_destination_port_range = item2[1].to_s
+      security_rule_direction = Fog::ARM::Network::Models::SecurityRuleDirection::Inbound
+      security_rule_priority = priority
+      security_rule_protocol = case item2[2].downcase
+        when 'tcp'
+          Fog::ARM::Network::Models::SecurityRuleProtocol::Tcp
+        when 'udp'
+          Fog::ARM::Network::Models::SecurityRuleProtocol::Udp
+        else
+          Fog::ARM::Network::Models::SecurityRuleProtocol::Asterisk
+        end
+      security_rule_provisioning_state = nil
+      security_rule_destination_addres_prefix = '*'
+      security_rule_source_port_range = '*'
+      security_rule_name = network_security_group_name + '-' + priority.to_s
+      sec_rules << { name: security_rule_name, resource_group: resource_group_name, protocol: security_rule_protocol, network_security_group_name: network_security_group_name, source_port_range: security_rule_source_port_range, destination_port_range: security_rule_destination_port_range, source_address_prefix: security_rule_source_addres_prefix, destination_address_prefix: security_rule_destination_addres_prefix, access: security_rule_access, priority: security_rule_priority, direction: security_rule_direction }
+      priority += 100
+      end
+    sec_rules
+  end
 end

--- a/components/cookbooks/azuresecgroup/.kitchen.yml
+++ b/components/cookbooks/azuresecgroup/.kitchen.yml
@@ -1,0 +1,31 @@
+<% load "/opt/oneops/inductor/circuit-oneops-1/monkey_patch.rb" %>
+driver:
+  name: proxy
+  host: 127.0.0.1
+  reset_command: "exit 0"
+  port: 22
+  transport: local
+provisioner:
+  require_chef_omnibus: false
+verifier:
+  name: serverspec
+  remote_exec: false
+  sudo: false
+  transport: local
+  test_serverspec_installed: false
+  additional_install_command: 'mkdir -p /opt/oneops/inductor/circuit-oneops-1/gems'
+  bundler_path: 'GEM_HOME=/opt/oneops/inductor/circuit-oneops-1/gems /usr/local/bin'
+  gemfile: test/integration/Gemfile
+  env_vars:
+    GEM_PATH: /usr/local/share/gems:/opt/oneops/inductor/circuit-oneops-1/gems
+platforms:
+  - name: centos-7.2
+suites:
+  - name: add
+    verifier:
+      patterns:
+      - test/integration/add/serverspec/add_spec.rb
+  - name: delete
+    verifier:
+      patterns:
+      - test/integration/delete/serverspec/delete_spec.rb

--- a/components/cookbooks/azuresecgroup/test/integration/add/serverspec/add_spec.rb
+++ b/components/cookbooks/azuresecgroup/test/integration/add/serverspec/add_spec.rb
@@ -1,0 +1,13 @@
+CIRCUIT_PATH="/opt/oneops/inductor/circuit-oneops-1"
+COOKBOOKS_PATH="#{CIRCUIT_PATH}/components/cookbooks"
+
+require "#{CIRCUIT_PATH}/components/spec_helper.rb"
+require "#{COOKBOOKS_PATH}/azure_base/test/integration/azure_spec_utils"
+
+
+#run the tests
+tsts = File.expand_path("tests", File.dirname(__FILE__))
+Dir.glob("#{tsts}/*.rb").each {|tst| require tst}
+
+
+

--- a/components/cookbooks/azuresecgroup/test/integration/add/serverspec/tests/add.rb
+++ b/components/cookbooks/azuresecgroup/test/integration/add/serverspec/tests/add.rb
@@ -2,7 +2,6 @@
 This spec has tests that validates a successfully completed oneops-azure deployment
 =end
 
-require 'spec_helper'
 require 'chef'
 require 'fog/azurerm'
 

--- a/components/cookbooks/azuresecgroup/test/integration/add/serverspec/tests/add.rb
+++ b/components/cookbooks/azuresecgroup/test/integration/add/serverspec/tests/add.rb
@@ -1,0 +1,71 @@
+=begin
+This spec has tests that validates a successfully completed oneops-azure deployment
+=end
+
+require 'spec_helper'
+require 'chef'
+require 'fog/azurerm'
+
+Dir.glob('/opt/oneops/inductor/circuit-oneops-1/components/cookbooks/azure_base/libraries/*.rb') do |lib|
+  require lib
+end
+require "/opt/oneops/inductor/circuit-oneops-1/components/cookbooks/azuresecgroup/libraries/network_security_group.rb"
+
+describe "Azure Security Group" do
+  before(:each) do
+    @spec_utils = AzureSpecUtils.new($node)
+  end
+
+  context "Security Group" do
+    it "should exist" do
+      nsgclient = AzureNetwork::NetworkSecurityGroup.new(@spec_utils.get_azure_creds)
+
+      rginfo = @spec_utils.get_resource_group_name
+      nsgname = $node['name']
+
+      nsg = nsgclient.get(rginfo, nsgname)
+      puts(nsg)
+      expect(nsg).not_to be_nil
+      expect(nsg.name).to eq(nsgname)
+    end
+
+    it "should have the right rule count" do
+      rulelist = $node['secgroup']['inbound'].tr('"[]\\', '').split(',')
+      puts("\t\tLooking for #{rulelist.length} rules in NSG.")      
+      nsgclient = AzureNetwork::NetworkSecurityGroup.new(@spec_utils.get_azure_creds)
+      rginfo = @spec_utils.get_resource_group_name
+      nsgname = $node['name']
+
+      nsgrules = nsgclient.list_rules(rginfo, nsgname)
+
+
+      expect(nsgrules.length).to eq(rulelist.length)
+    end
+
+    it "should set rules correctly" do
+      nsgname = $node['name']      
+      rginfo = @spec_utils.get_resource_group_name      
+      rulelist = $node['secgroup']['inbound'].tr('"[]\\', '').split(',')
+      ruleset = @spec_utils.get_azure_rule_definition(rginfo, nsgname, rulelist, $node)
+
+#      puts(ruleset)
+    
+      nsgclient = AzureNetwork::NetworkSecurityGroup.new(@spec_utils.get_azure_creds)
+      
+      ruleset.each do |rset|
+        puts("\t\tTesting Rule #{rset[:name]}")
+        nsgrule = nsgclient.get_rule(rginfo, nsgname, rset[:name])
+
+        expect(nsgrule).not_to be_nil
+        expect(nsgrule.protocol).to eq(rset[:protocol])
+        expect(nsgrule.source_port_range).to eq(rset[:source_port_range])
+        expect(nsgrule.destination_port_range).to eq(rset[:destination_port_range])
+        expect(nsgrule.source_address_prefix).to eq(rset[:source_address_prefix])
+        expect(nsgrule.destination_address_prefix).to eq(rset[:destination_address_prefix])
+        expect(nsgrule.access).to eq(rset[:access])
+        expect(nsgrule.priority).to eq(rset[:priority])
+        expect(nsgrule.direction).to eq(rset[:direction])
+      end
+    end
+  end
+end

--- a/components/cookbooks/azuresecgroup/test/integration/delete/serverspec/delete_spec.rb
+++ b/components/cookbooks/azuresecgroup/test/integration/delete/serverspec/delete_spec.rb
@@ -1,0 +1,11 @@
+CIRCUIT_PATH="/opt/oneops/inductor/circuit-oneops-1"
+COOKBOOKS_PATH="#{CIRCUIT_PATH}/components/cookbooks"
+
+require "#{CIRCUIT_PATH}/components/spec_helper.rb"
+require "#{COOKBOOKS_PATH}/azure_base/test/integration/azure_spec_utils"
+
+#run the tests
+tsts = File.expand_path("tests", File.dirname(__FILE__))
+Dir.glob("#{tsts}/*.rb").each {|tst| require tst}
+
+

--- a/components/cookbooks/azuresecgroup/test/integration/delete/serverspec/tests/delete.rb
+++ b/components/cookbooks/azuresecgroup/test/integration/delete/serverspec/tests/delete.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'chef'
+require 'fog/azurerm'
+
+Dir.glob('/opt/oneops/inductor/circuit-oneops-1/components/cookbooks/azure_base/libraries/*.rb') do |lib|
+  require lib
+end
+require "/opt/oneops/inductor/circuit-oneops-1/components/cookbooks/azuresecgroup/libraries/network_security_group.rb"
+
+describe "Azure Security Group" do
+  before(:each) do
+    @spec_utils = AzureSpecUtils.new($node)
+  end
+
+  context "Security Group" do
+    it "should not exist" do
+      nsgclient = AzureNetwork::NetworkSecurityGroup.new(@spec_utils.get_azure_creds)
+
+      rginfo = @spec_utils.get_resource_group_name
+      nsgname = $node['name']
+
+      nsg = nsgclient.get(rginfo, nsgname)
+      expect(nsg).to be_nil
+    end
+  end
+end

--- a/components/cookbooks/azuresecgroup/test/integration/delete/serverspec/tests/delete.rb
+++ b/components/cookbooks/azuresecgroup/test/integration/delete/serverspec/tests/delete.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'chef'
 require 'fog/azurerm'
 

--- a/components/cookbooks/secgroup/.kitchen.yml
+++ b/components/cookbooks/secgroup/.kitchen.yml
@@ -1,0 +1,31 @@
+<% load "/opt/oneops/inductor/circuit-oneops-1/monkey_patch.rb" %>
+driver:
+  name: proxy
+  host: 127.0.0.1
+  reset_command: "exit 0"
+  port: 22
+  transport: local
+provisioner:
+  require_chef_omnibus: false
+verifier:
+  name: serverspec
+  remote_exec: false
+  sudo: false
+  transport: local
+  test_serverspec_installed: false
+  additional_install_command: 'mkdir -p /opt/oneops/inductor/circuit-oneops-1/gems'
+  bundler_path: 'GEM_HOME=/opt/oneops/inductor/circuit-oneops-1/gems /usr/local/bin'
+  gemfile: test/integration/Gemfile
+  env_vars:
+    GEM_PATH: /usr/local/share/gems:/opt/oneops/inductor/circuit-oneops-1/gems
+platforms:
+  - name: centos-7.2
+suites:
+  - name: add
+    verifier:
+      patterns:
+      - test/integration/add/serverspec/add_spec.rb
+  - name: delete
+    verifier:
+      patterns:
+      - test/integration/delete/serverspec/delete_spec.rb

--- a/components/cookbooks/secgroup/test/integration/add/serverspec/add_spec.rb
+++ b/components/cookbooks/secgroup/test/integration/add/serverspec/add_spec.rb
@@ -1,0 +1,13 @@
+CIRCUIT_PATH="/opt/oneops/inductor/circuit-oneops-1"
+COOKBOOKS_PATH="#{CIRCUIT_PATH}/components/cookbooks"
+AZURE_TESTS_PATH="#{COOKBOOKS_PATH}/azuresecgroup/test/integration/add/serverspec/tests"
+
+require "#{CIRCUIT_PATH}/components/spec_helper.rb"
+require "#{COOKBOOKS_PATH}/azure_base/test/integration/spec_utils"
+
+provider = SpecUtils.new($node).get_provider
+if provider =~ /azure/
+  require "#{COOKBOOKS_PATH}/azure_base/test/integration/azure_spec_utils"
+  Dir.glob("#{AZURE_TESTS_PATH}/*.rb").each {|tst| require tst}
+end
+

--- a/components/cookbooks/secgroup/test/integration/delete/serverspec/delete_spec.rb
+++ b/components/cookbooks/secgroup/test/integration/delete/serverspec/delete_spec.rb
@@ -1,0 +1,12 @@
+CIRCUIT_PATH="/opt/oneops/inductor/circuit-oneops-1"
+COOKBOOKS_PATH="#{CIRCUIT_PATH}/components/cookbooks"
+AZURE_TESTS_PATH="#{COOKBOOKS_PATH}/azuresecgroup/test/integration/delete/serverspec/tests"
+
+require "#{CIRCUIT_PATH}/components/spec_helper.rb"
+require "#{COOKBOOKS_PATH}/azure_base/test/integration/spec_utils"
+
+provider = SpecUtils.new($node).get_provider
+if provider =~ /azure/
+  require "#{COOKBOOKS_PATH}/azure_base/test/integration/azure_spec_utils"
+  Dir.glob("#{AZURE_TESTS_PATH}/*.rb").each {|tst| require tst}
+end


### PR DESCRIPTION
Adding the Azure Security Group Test Cases:
For Add test that: 1) It exists with the right name, 2) has the right rule count, 3) applied the correct rules.
For Delete test that: 1) it doesn't exist anymore. 