### PR TITLE
instance size and os type change requires replace

### DIFF
--- a/components/cookbooks/compute/recipes/update.rb
+++ b/components/cookbooks/compute/recipes/update.rb
@@ -2,4 +2,9 @@
 # Cookbook Name:: compute
 # Recipe:: update
 #
-include_recipe "compute::add"
+if (node[:workorder][:rfcCi][:ciBaseAttributes].has_key?("size")  &&
+    (node[:workorder][:rfcCi][:ciBaseAttributes][:size] != node[:workorder][:rfcCi][:ciAttributes][:size]))
+  OOLog.fatal("Instance size doens't match with current configuration, consider replacing compute or change instace size to original")
+else
+  include_recipe "compute::add"
+end

--- a/components/cookbooks/os/recipes/update.rb
+++ b/components/cookbooks/os/recipes/update.rb
@@ -2,4 +2,9 @@
 # Cookbook Name:: os
 # Recipe:: update
 #
-include_recipe "os::add"
+if (node[:workorder][:rfcCi][:ciBaseAttributes].has_key?("ostype") &&
+    (node[:workorder][:rfcCi][:ciBaseAttributes][:ostype] != node[:workorder][:rfcCi][:ciAttributes][:ostype]))
+  exit_with_error "OS type doens't match with current configuration, consider replacing compute or change OS type to original"
+else
+  include_recipe "os::add"
+end


### PR DESCRIPTION
After deployment is completed, if user just changes instance size or OS type, its ask for commit and deploy. Users can hit deploy and deployment goes through without any issue and creates the illusion that whatever changes are done, are now committed and deployed. Then users came back and say that they are still seeing the same compute and OS. In this case, we then suggest users to replace compute.