### PR TITLE
remove hard-coded path to /home and use value specified from workorder

### DIFF
--- a/components/cookbooks/user/test/integration/add/serverspec/add_spec.rb
+++ b/components/cookbooks/user/test/integration/add/serverspec/add_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe user($node['user']['username']) do
   it { should exist }
   it { should have_login_shell $node['user']['login_shell'] }
-  it { should have_home_directory "/home/#{$node['user']['username']}" }
+  it { should have_home_directory "#{$node['user']['home_directory']}" }
 end
 
 if !$node['user']['username'].to_s.empty? && !$node['user']['group'].eql?('[]')


### PR DESCRIPTION
Previously the value for home directory was hard-coded to begin with /home, however this can be any directory as configured by user.