### PR TITLE
changed default location for pid

### DIFF
--- a/components/cookbooks/zookeeper/attributes/default.rb
+++ b/components/cookbooks/zookeeper/attributes/default.rb
@@ -19,7 +19,7 @@ default[:zookeeper][:cluster_name]           = node[:cluster_name]
 default[:zookeeper][:home_dir]               = '/usr/lib/zookeeper'
 default[:zookeeper][:conf_dir]               = '/etc/zookeeper'
 default[:zookeeper][:log_dir]                = '/var/log/zookeeper'
-default[:zookeeper][:pid_dir]                = '/var/run/zookeeper'
+default[:zookeeper][:pid_dir]                = '/usr/lib/tmpfiles.d/zookeeper'
 
 default[:zookeeper][:journal_dir]          = '/var/zookeeper/txlog'
 default[:zookeeper][:data_dir]             = '/var/zookeeper/data'


### PR DESCRIPTION
Examined /var/run on system, it's actually a symlink to /run and it's actually a tmpfs mountpoint:
A tmpfs filesystem is an in-memory filesystem: anything there disappears when the system reboots.
Changing defualt location for PID so that it will survive reboot.