### PR TITLE
Fix a problem setting up the Spark Thrift server

### DIFF
--- a/components/cookbooks/spark-v2/recipes/spark_thriftserver.rb
+++ b/components/cookbooks/spark-v2/recipes/spark_thriftserver.rb
@@ -46,10 +46,10 @@ if is_client_only && configNode.has_key?('enable_thriftserver') && (configNode['
     if !passNodeText.empty?
       private_pass = passNodeText
     else
-      private_pass = ""
+      # Leave private_pass as the randomly generated value
     end
   else
-    private_pass = ""
+    # Leave private_pass as the randomly generated value
   end
 
   # Make sure the keystore directory exists


### PR DESCRIPTION
The randomly generated key was being wiped out when setting
up the Spark Thrift Server for the first time.