### PR TITLE
Removed bundler install for oneops user

### DIFF
--- a/components/cookbooks/compute/files/default/install_base.sh
+++ b/components/cookbooks/compute/files/default/install_base.sh
@@ -201,7 +201,6 @@ if [ -n "$rubygems_proxy" ]; then
     gem source
 fi
 set -e
-gem install bundler --no-ri --no-rdoc
 EOF
 set -e
 


### PR DESCRIPTION
The install was left in by mistake. I meant to only set up proxy info for oneops user. 