### PR TITLE
Force chef to override OHAI for resource service to use SysInitV

### DIFF
--- a/components/cookbooks/activemq/recipes/add.rb
+++ b/components/cookbooks/activemq/recipes/add.rb
@@ -398,12 +398,14 @@ end
 
 if node.workorder.cloud.ciAttributes.priority == "1"
     service 'activemq' do
+        provider Chef::Provider::Service::Init::Redhat
         supports :restart => true, :status => true, :stop => true, :start => true
         action [:enable, :start]
     end
 else
     # disable and stop secondary
     service 'activemq' do
+        provider Chef::Provider::Service::Init::Redhat
         supports :restart => true, :status => true, :stop => true, :start => true
         action [:disable, :stop]
     end

--- a/components/cookbooks/activemq/recipes/delete.rb
+++ b/components/cookbooks/activemq/recipes/delete.rb
@@ -4,6 +4,7 @@
 #
 
 service "activemq" do
+  provider Chef::Provider::Service::Init::Redhat
   action [:stop, :disable]
 end
 


### PR DESCRIPTION
Force chef to override OHAI for resource service.  We are currently using SysInitV
and not using systemd thus it's not applicable.  There still a need to refactor
this cookbook to fully suport systemd service.