### PR TITLE
Fixed a bug with multiple volume groups

### DIFF
--- a/components/cookbooks/volume/test/integration/volume_spec.rb
+++ b/components/cookbooks/volume/test/integration/volume_spec.rb
@@ -50,7 +50,8 @@ else
   size_vm = `df -BG | grep #{$mount_point}| awk '{print $2}'`.chop.to_i
 end
 if !is_windows
-  vg = `vgdisplay -c`
+  vg_name = execute_command("lvs | grep #{$node['workorder']['rfcCi']['ciName']}").stdout.split(' ')[1]
+  vg = `vgdisplay -c #{vg_name}`
   vg_size = ((vg.split(':')[11].to_f)/1024/1024).round(0).to_i
   vg_lvcount = vg.split(':')[5].to_i
 end


### PR DESCRIPTION
When persistent and ephemeral storage are used in the same pack
it will result in 2 volume groups created.
The code that determine VG size will pick arbitrary volume group.
Fixed by explicitly specifying VG when checking its size with vgdisplay