### PR TITLE
OS Kitchen CI Test issues resolved

### DIFF
--- a/components/cookbooks/os/recipes/network.rb
+++ b/components/cookbooks/os/recipes/network.rb
@@ -17,7 +17,7 @@ end
 full_hostname = node[:full_hostname]
 _hosts[full_hostname] = node.workorder.payLoad.ManagedVia[0]["ciAttributes"]["private_ip"]
 
-execute("mkdir -p /etc/cloud")
+execute('mkdir -p /etc/cloud/cloud.cfg.d')
 
 bash "set-hostname" do
   code <<-EOH

--- a/components/cookbooks/os/test/integration/add/serverspec/centos_redhat_7.rb
+++ b/components/cookbooks/os/test/integration/add/serverspec/centos_redhat_7.rb
@@ -119,6 +119,6 @@ describe user("oneops") do
   it { should exist }
 end
 
-describe command('su - oneops -c "gem source" | grep -m 1 "http"') do
+describe command('gem source | grep -m 1 "http"') do
   its(:stdout) { should eq root_gem_source}
 end

--- a/components/cookbooks/os/test/integration/add/serverspec/checklist.yml
+++ b/components/cookbooks/os/test/integration/add/serverspec/checklist.yml
@@ -49,7 +49,6 @@ gems:
   - azure_mgmt_network
   - azure_mgmt_storage
   - azure_mgmt_resources
-  - azure
   - rack
 files:
   - name: /home/oneops/shared
@@ -174,7 +173,7 @@ files:
 # ---------------------------------------
   - name: /etc/cloud/cloud.cfg
     type: f
-    mode: 664
+    mode: 644
     owner: root
     group: root
 # ---------------------------------------
@@ -204,8 +203,7 @@ files:
 # ---------------------------------------
   - name: /etc/ssh/sshd_config.backup
     type: f
-    mode: 644
+    mode: 600
     owner: root
     group: root
 # ---------------------------------------
-


### PR DESCRIPTION
Added cloud.cfg.d directory so that 99_hostname.cfg file can be created.
Remove su - oneops as we are already logged on as "oneops" user so this is redundant and tests are failing due to this.
Azure gem is removed from gem list as this never gets installed in the VMs.
File modes have been updated.