### PR TITLE
Force any service resource to use SystemInitV instead of systemd.

### DIFF
--- a/components/cookbooks/daemon/recipes/add.rb
+++ b/components/cookbooks/daemon/recipes/add.rb
@@ -40,6 +40,7 @@ end
 
 # enable daemon service
 service "#{service_name}" do
+  provider Chef::Provider::Service::Init::Redhat if node[:platform_family].include?("rhel")
   action :enable
 end
 
@@ -54,6 +55,7 @@ end
 
 # restart daemon service when pattern has been specified
 service "#{service_name}" do
+  provider Chef::Provider::Service::Init::Redhat if node[:platform_family].include?("rhel")
   pattern "#{pat}"
   action :restart
   only_if { !pat.empty? }

--- a/components/cookbooks/daemon/recipes/delete.rb
+++ b/components/cookbooks/daemon/recipes/delete.rb
@@ -23,12 +23,14 @@ pat = attrs[:pattern] || ''
 if pat.empty?
   # set basic service
   service "#{service_name}" do
+    provider Chef::Provider::Service::Init::Redhat if node[:platform_family].include?("rhel")
     action [:disable,:stop]
   end
 
 else
   # set pattern based service
   service "#{service_name}" do
+    provider Chef::Provider::Service::Init::Redhat if node[:platform_family].include?("rhel")
     pattern "#{pat}"
     action [:disable,:stop]
   end

--- a/components/cookbooks/daemon/recipes/restart.rb
+++ b/components/cookbooks/daemon/recipes/restart.rb
@@ -17,6 +17,7 @@ end
 
 # restart daemon service when pattern has been specified
 service "#{service_name}" do
+  provider Chef::Provider::Service::Init::Redhat if node[:platform_family].include?("rhel")
   pattern "#{pat}"
   action :restart
   only_if { !pat.empty? }

--- a/components/cookbooks/daemon/recipes/start.rb
+++ b/components/cookbooks/daemon/recipes/start.rb
@@ -17,6 +17,7 @@ end
 
 # start daemon service when pattern has been specified
 service "#{service_name}" do
+	provider Chef::Provider::Service::Init::Redhat if node[:platform_family].include?("rhel")
 	pattern "#{pat}"
 	action :start
 	only_if { !pat.empty? }

--- a/components/cookbooks/daemon/recipes/stop.rb
+++ b/components/cookbooks/daemon/recipes/stop.rb
@@ -16,6 +16,7 @@ end
 
 # stop daemon service when pattern has been specified
 service "#{service_name}" do
+	provider Chef::Provider::Service::Init::Redhat if node[:platform_family].include?("rhel")
 	pattern "#{pat}"
 	action :stop
 	only_if { !pat.empty? }


### PR DESCRIPTION
Force any service resource to use SystemInitV since this component is using /etc/init.d/ instead of newer systemd startup style.