### PR TITLE
nc command changed to remove -z 

### DIFF
--- a/components/cookbooks/solrcloud/templates/default/check_solr_zk_conn.sh.erb
+++ b/components/cookbooks/solrcloud/templates/default/check_solr_zk_conn.sh.erb
@@ -35,7 +35,7 @@ log_echo "Total number of available ZK nodes = ${#zk_list[@]}"
 
 ping_zk () {
   zk=$1
-  (nc -z $1 2181)
+  (nc $1 2181 </dev/null)
   ret=$?
   return $ret
 }


### PR DESCRIPTION
'nc -z host port' command doesn't work on centos 7 as there is no -z option.
Changed the command to 'nc host port </dev/null'