### PR TITLE
Objectstore openstack issues resolved

### DIFF
--- a/components/cookbooks/objectstore/files/default/objectstore
+++ b/components/cookbooks/objectstore/files/default/objectstore
@@ -150,7 +150,6 @@ def download_directory_or_file(conn, options, argv)
     else
       puts "remote_file: #{remote_file.key}"
     end
-
     if remote_file.content_type == 'application/directory'
       new_dir = local_dir + remote_file.key
       puts "creating dir: #{new_dir}"
@@ -176,7 +175,6 @@ def download_directory_or_file(conn, options, argv)
           exit 1
         end
       end
-
       # if bucket is supplied file will be empty
       puts "match on file: #{file} #{remote_file.key}"
       if file.empty? || file == remote_file.key

--- a/components/cookbooks/objectstore/files/default/objectstore
+++ b/components/cookbooks/objectstore/files/default/objectstore
@@ -89,30 +89,30 @@ def upload_directory_or_file(conn, argv, provider)
   files.each_with_index do |file, idx|
     puts "#{idx + 1}/#{files.size}) Upload: #{file} to bucket: #{bucket_name}"
     case provider
-      when /OpenStack/
-        File.open(file_name) do |file_upload|
-          segment = 0
-          until file_upload.eof?
-            segment += 1
-            offset = 0
+    when /OpenStack/
+      File.open(file_name) do |file_upload|
+        segment = 0
+        until file_upload.eof?
+          segment += 1
+          offset = 0
 
-            # upload segment to cloud files
-            segment_suffix = segment.to_s.rjust(10, '0')
-            conn.put_object(bucket_name, "#{file_name}/#{segment_suffix}", nil) do
-              if offset <= SEGMENT_LIMIT - BUFFER_SIZE
-                buf = file_upload.read(BUFFER_SIZE).to_s
-                offset += buf.size
-                buf
-              else
-                ''
-              end
+          # upload segment to cloud files
+          segment_suffix = segment.to_s.rjust(10, '0')
+          conn.put_object(bucket_name, "#{file_name}/#{segment_suffix}", nil) do
+            if offset <= SEGMENT_LIMIT - BUFFER_SIZE
+              buf = file_upload.read(BUFFER_SIZE).to_s
+              offset += buf.size
+              buf
+            else
+              ''
             end
           end
         end
-        # write manifest file
-        conn.put_object_manifest(bucket_name, file_name, 'X-Object-Manifest' => "#{bucket_name}/#{file_name}/")
-      when /Azure/
-        directory.files.create(:key => file, :body => File.open(file))
+      end
+      # write manifest file
+      conn.put_object_manifest(bucket_name, file_name, 'X-Object-Manifest' => "#{bucket_name}/#{file_name}/")
+    when /Azure/
+      directory.files.create(:key => file, :body => File.open(file))
     end
     size += File.size(file)
   end
@@ -150,6 +150,7 @@ def download_directory_or_file(conn, options, argv)
     else
       puts "remote_file: #{remote_file.key}"
     end
+
     if remote_file.content_type == 'application/directory'
       new_dir = local_dir + remote_file.key
       puts "creating dir: #{new_dir}"
@@ -175,6 +176,7 @@ def download_directory_or_file(conn, options, argv)
           exit 1
         end
       end
+
       # if bucket is supplied file will be empty
       puts "match on file: #{file} #{remote_file.key}"
       if file.empty? || file == remote_file.key
@@ -240,44 +242,44 @@ conn = nil
 provider = creds['provider']
 
 case provider
-  when /OpenStack/
-    require 'fog'
-    puts "Connecting to #{creds['openstack_auth_url']} as #{creds['openstack_username']}..."
-    conn = Fog::Storage.new(creds_sym)
-  when /Azure/
-    require 'fog/azurerm'
-    puts "Connecting to #{creds['azure_storage_account_name']}..."
-    conn = Fog::Storage::AzureRM.new(creds)
-  else
-    puts "Provider #{provider} not supported!"
-    exit 1
+when /OpenStack/
+  require 'fog'
+  puts "Connecting to #{creds['openstack_auth_url']} as #{creds['openstack_username']}..."
+  conn = Fog::Storage.new(creds_sym)
+when /Azure/
+  require 'fog/azurerm'
+  puts "Connecting to #{creds['azure_storage_account_name']}..."
+  conn = Fog::Storage::AzureRM.new(creds)
+else
+  puts "Provider #{provider} not supported!"
+  exit 1
 end
 
 case action
-  when 'list'
-    list_directories_or_files(conn, options, ARGV)
+when 'list'
+  list_directories_or_files(conn, options, ARGV)
 
-  when 'delete'
-    if ARGV.size < 2
-      puts 'Usage: objectstore delete <container>/<blob>'
-      exit 1
-    end
-    delete_directory_or_file(conn, ARGV)
-
-  when 'upload'
-    if ARGV.size < 3
-      puts 'Usage: upload <directory/file> <container>'
-      exit 1
-    end
-    upload_directory_or_file(conn, ARGV, provider)
-
-  when 'download'
-    if ARGV.size < 3
-      puts 'Usage: objectstore download <container/blob> <local-path>'
-      exit 1
-    end
-    download_directory_or_file(conn, options, ARGV)
-  else
-    puts "Action #{action} not supported!"
+when 'delete'
+  if ARGV.size < 2
+    puts 'Usage: objectstore delete <container>/<blob>'
     exit 1
+  end
+  delete_directory_or_file(conn, ARGV)
+
+when 'upload'
+  if ARGV.size < 3
+    puts 'Usage: upload <directory/file> <container>'
+    exit 1
+  end
+  upload_directory_or_file(conn, ARGV, provider)
+
+when 'download'
+  if ARGV.size < 3
+    puts 'Usage: objectstore download <container/blob> <local-path>'
+    exit 1
+  end
+  download_directory_or_file(conn, options, ARGV)
+else
+  puts "Action #{action} not supported!"
+  exit 1
 end

--- a/components/cookbooks/objectstore/files/default/objectstore
+++ b/components/cookbooks/objectstore/files/default/objectstore
@@ -4,6 +4,10 @@ require 'rubygems'
 require 'optparse'
 require 'json'
 
+# Segment limit and buffer size for Openstack file upload
+SEGMENT_LIMIT = 5 * 1024 * 1024 * 1024 - 1       # 5GB -1
+BUFFER_SIZE = 1024 * 1024                        # 1MB
+
 def list_directories_or_files(conn, options, argv)
   # check if need to list files or directories
   if argv.size > 1
@@ -39,12 +43,11 @@ def delete_directory_or_file(conn, argv)
     remote_parts = remote_object.split('/')
     remote_parts.shift
     remote_file = remote_parts.join('/')
-    file_to_delete = directory.files.get(remote_file)
-    if file_to_delete.nil?
-      puts "remote file does not exist: #{remote_file}"
-    else
-      puts "removing file: #{remote_file}"
-      file_to_delete.destroy
+    directory.files.each do |file|
+      if(file.key == remote_file)
+        puts "removing file: #{file.key} from #{remote_dir}"
+        file.destroy
+      end
     end
   else
     directory = conn.directories.get(remote_object)
@@ -57,7 +60,7 @@ def delete_directory_or_file(conn, argv)
   end
 end
 
-def upload_directory_or_file(conn, argv)
+def upload_directory_or_file(conn, argv, provider)
   file_name = argv[1]
   bucket_name = argv[2]
   file_filter = argv[3] || '*'
@@ -85,7 +88,32 @@ def upload_directory_or_file(conn, argv)
   size = 0
   files.each_with_index do |file, idx|
     puts "#{idx + 1}/#{files.size}) Upload: #{file} to bucket: #{bucket_name}"
-    directory.files.create(:key => file, :body => File.open(file))
+    case provider
+      when /OpenStack/
+        File.open(file_name) do |file_upload|
+          segment = 0
+          until file_upload.eof?
+            segment += 1
+            offset = 0
+
+            # upload segment to cloud files
+            segment_suffix = segment.to_s.rjust(10, '0')
+            conn.put_object(bucket_name, "#{file_name}/#{segment_suffix}", nil) do
+              if offset <= SEGMENT_LIMIT - BUFFER_SIZE
+                buf = file_upload.read(BUFFER_SIZE).to_s
+                offset += buf.size
+                buf
+              else
+                ''
+              end
+            end
+          end
+        end
+        # write manifest file
+        conn.put_object_manifest(bucket_name, file_name, 'X-Object-Manifest' => "#{bucket_name}/#{file_name}/")
+      when /Azure/
+        directory.files.create(:key => file, :body => File.open(file))
+    end
     size += File.size(file)
   end
   finish_time = Time.now
@@ -156,7 +184,7 @@ def download_directory_or_file(conn, options, argv)
           start_time = Time.now
           # Download files in chunks
           directory.files.get(remote_file.key) do |chunk, remaining_bytes, total_bytes|
-            print( "\rDownloaded: #{total_bytes - remaining_bytes} of #{total_bytes}")
+            print("\rDownloaded: #{total_bytes - remaining_bytes} of #{total_bytes}")
             local_file.write(chunk)
           end
           finish_time = Time.now
@@ -211,46 +239,47 @@ end
 creds = JSON.parse(File.read('/etc/objectstore_creds.json'))
 creds_sym = Hash[creds.map { |(k, v)| [k.to_sym, v] }]
 conn = nil
+provider = creds['provider']
 
-case creds['provider']
-when /OpenStack/
-  require 'fog'
-  puts "Connecting to #{creds['openstack_auth_url']} as #{creds['openstack_username']}..."
-  conn = Fog::Storage.new(creds_sym)
-when /Azure/
-  require 'fog/azurerm'
-  puts "Connecting to #{creds['azure_storage_account_name']}..."
-  conn = Fog::Storage::AzureRM.new(creds)
-else
-  puts "Provider #{creds['provider']} not supported!"
-  exit 1
+case provider
+  when /OpenStack/
+    require 'fog'
+    puts "Connecting to #{creds['openstack_auth_url']} as #{creds['openstack_username']}..."
+    conn = Fog::Storage.new(creds_sym)
+  when /Azure/
+    require 'fog/azurerm'
+    puts "Connecting to #{creds['azure_storage_account_name']}..."
+    conn = Fog::Storage::AzureRM.new(creds)
+  else
+    puts "Provider #{provider} not supported!"
+    exit 1
 end
 
 case action
-when 'list'
-  list_directories_or_files(conn, options, ARGV)
+  when 'list'
+    list_directories_or_files(conn, options, ARGV)
 
-when 'delete'
-  if ARGV.size < 2
-    puts 'Usage: objectstore delete <container>/<blob>'
-    exit 1
-  end
-  delete_directory_or_file(conn, ARGV)
+  when 'delete'
+    if ARGV.size < 2
+      puts 'Usage: objectstore delete <container>/<blob>'
+      exit 1
+    end
+    delete_directory_or_file(conn, ARGV)
 
-when 'upload'
-  if ARGV.size < 3
-    puts 'Usage: upload <directory/file> <container>'
-    exit 1
-  end
-  upload_directory_or_file(conn, ARGV)
+  when 'upload'
+    if ARGV.size < 3
+      puts 'Usage: upload <directory/file> <container>'
+      exit 1
+    end
+    upload_directory_or_file(conn, ARGV, provider)
 
-when 'download'
-  if ARGV.size < 3
-    puts 'Usage: objectstore download <container/blob> <local-path>'
+  when 'download'
+    if ARGV.size < 3
+      puts 'Usage: objectstore download <container/blob> <local-path>'
+      exit 1
+    end
+    download_directory_or_file(conn, options, ARGV)
+  else
+    puts "Action #{action} not supported!"
     exit 1
-  end
-  download_directory_or_file(conn, options, ARGV)
-else
-  puts "Action #{action} not supported!"
-  exit 1
 end


### PR DESCRIPTION
**Upload Error**
The objectstore upload fails for large files in case of openstack, as block size should be less than 5GB for openstack(swift), So when we try to upload a file greater than 5GB it fails.

**Delete Error**
When we try to delete a large file the objectstore crashes with the following exception: 
“Failed to allocate memory”. This is due to the fact that in objectstore file.get is called, when the file size is large the system was not able to load file into the memory and exception occurs.

**Objectstore openstack issues has been fixed.**
- Upload large files error resolved.
- Delete large files error resolved.

**Reference WM-JIRA Ticket: PLONEOPS-15806**