### PR TITLE
Fixed issue with backward compatibility

### DIFF
--- a/components/cookbooks/volume/libraries/Storage.rb
+++ b/components/cookbooks/volume/libraries/Storage.rb
@@ -179,10 +179,10 @@ module VolumeComponent
     def attach (max_retry_count = 5, sleep_sec = 10)
 
       #storage is attached and device_id is not assigned (not determined) - means it was created with the old code - detach and re-attach
-      detach if (get_is_attached && !get_assigned_device_id)
+      #detach if (get_is_attached && !get_assigned_device_id)
 
       #storage attached and device_id is assigned - just exit
-      return if (get_is_attached && get_assigned_device_id)
+      return if (get_is_attached) # && get_assigned_device_id)
 
       #capture current device list from /dev
       start_time = Time.now.to_i

--- a/components/cookbooks/volume/recipes/add.rb
+++ b/components/cookbooks/volume/recipes/add.rb
@@ -102,7 +102,7 @@ ruby_block 'create-iscsi-volume-ruby-block' do
 
     storage_devices.each do |storage_device|
       storage_device.attach
-      dev_list += storage_device.assigned_device_id + " "
+      dev_list += storage_device.assigned_device_id + " " if storage_device.assigned_device_id
     end
 
     has_created_raid = false
@@ -397,15 +397,7 @@ ruby_block 'create-storage-non-ephemeral-volume' do
     #2. User can extend storage and can extend volume
     #3. Replace storage doesn't do anything, so it will not allow usre to change volume component too
 
-    check_persistent = false
-    node.workorder.payLoad[:DependsOn].each do |dep|
-      if dep["ciClassName"] =~ /Storage/
-        check_persistent = true
-        break
-      end
-    end
-
-    if ((check_persistent && rfc_action == "update" && token_class =~ /openstack/) || (rfc_action == "update" && storageUpdated))
+    if ((!storage.nil? && rfc_action == "update" && token_class =~ /openstack|azure/) || (rfc_action == "update" && storageUpdated))
       new_size = size
       old_size = rfcCi[:ciBaseAttributes][:size]
 


### PR DESCRIPTION
some providers may attach storage to an arbitrary device id, we determine the actual (assigned) device id by issuing attach command and watching a folder on the vm - for instance for azure it's /dev/sd*. Once a new entry appears in that folder - that's our device id.
The problem with the old code is that it's not storing that device id anywhere, and therefore when it runs for the second time it has no way to determine where a particular storage has been attached to.
The new code fixes that by storing device id in a service file (under /opt/oneops/storage_devices).
When we create an assembly using the old code, and then switch to new code and do an update - the update runs but sees no service file, and it tries to simply detach and re-attach the storage. This leads to a problem, because the volume group is already using the storage we're detaching. Fixed by not doing detach