### PR TITLE
Fixed issue with deleting volume

### DIFF
--- a/components/cookbooks/volume/recipes/delete.rb
+++ b/components/cookbooks/volume/recipes/delete.rb
@@ -57,7 +57,14 @@ if rfcAttrs.has_key?("mount_point") && !rfcAttrs["mount_point"].empty?
 
     ruby_block "killing open files at #{mount_point}" do
       block do
+       #1 kill processes that are accesing the mount
        execute_command("lsof #{mount_point} | awk '{print $2}' | grep -v PID | uniq | xargs kill -9")
+
+       #2 remove swap file from the mount
+         swap_file = execute_command("cat /proc/swaps | grep #{mount_point} | awk '{print $1}'").stdout.chop
+         if !swap_file.nil? && !swap_file.empty?
+           execute_command("swapoff #{swap_file}")
+         end
       end
       only_if { has_mounted }
     end


### PR DESCRIPTION
A mount point could not be unmounted because it had a swap file.
Added logic to check for swap files under a mount, and execute swapoff if found