### PR TITLE
Undefined Local Variables

### DIFF
--- a/components/cookbooks/fqdn/libraries/fqdn_base.rb
+++ b/components/cookbooks/fqdn/libraries/fqdn_base.rb
@@ -200,11 +200,6 @@ module Fqdn
             else
              dns_record = attrs[:public_ip]
             end
-    
-            if location == ".int" || dns_entry == nil || dns_entry.empty?
-              dns_record = attrs[:private_ip]
-            end
-    
           when /Lb/
             dns_record = attrs[:dns_record]
           when /Cluster/


### PR DESCRIPTION
Variables are not defined before compare. TODO: Introduce condition to assign Private IP in DNS_RECORD.