### PR TITLE
Removed require gem statement from a library

### DIFF
--- a/components/cookbooks/azure_base/libraries/utils.rb
+++ b/components/cookbooks/azure_base/libraries/utils.rb
@@ -1,4 +1,3 @@
-require 'azure_mgmt_resources'
 require File.expand_path('../../libraries/logger.rb', __FILE__)
 
 module Utils


### PR DESCRIPTION
the require statement in the library would run for every cookbook that depends on that library
even if it runs on Openstack machine that does not neccesserily has azure gems installed