### PR TITLE
Fixed replace issue for Azure VMs with unmanaged disks

### DIFF
--- a/components/cookbooks/azure/recipes/del_blobs.rb
+++ b/components/cookbooks/azure/recipes/del_blobs.rb
@@ -2,16 +2,10 @@ os_disk_blobname = (node['vhd_uri'].split("/").last)
 OOLog.info("Deleting os_disk : #{os_disk_blobname}")
 
 rg_manager = AzureBase::ResourceGroupManager.new(node)
+storage_account_name = node['storage_account']
+creds = rg_manager.creds
+creds[:azure_storage_access_key] = Fog::Storage::AzureRM.new(rg_manager.creds).get_storage_access_keys(rg_manager.rg_name, storage_account_name)[1].value
+creds[:azure_storage_account_name] = storage_account_name
 
-dd_manager = Datadisk.new(rg_manager.creds, rg_manager.rg_name, node['storage_account'], node['platform-resource-group'], nil, nil)
-dd_manager.set_storage_account_service(rg_manager.creds)
-dd_manager.delete_disk_by_name(os_disk_blobname)
-
-if node['datadisk_uri'] != nil
-data_disk_blobname = (node['datadisk_uri'].split("/").last)
-
-  if data_disk_blobname.include?(node['storage_account'])
-    OOLog.info("Deleting data_disk : #{data_disk_blobname}")
-    dd_manager.delete_disk_by_name(data_disk_blobname)    
-  end
-end
+storage_service = Fog::Storage::AzureRM.new(creds)
+storage_service.delete_disk(os_disk_blobname, options = {})


### PR DESCRIPTION
Also removed the code to delete a data disk, it is not tied to VM lifecycle
hence should not be done at compute replace/delete step, and instead the actual disk deletion happens in storage component.