### PR TITLE
fix for json pure issue

### DIFF
--- a/components/cookbooks/compute/files/default/install_base.sh
+++ b/components/cookbooks/compute/files/default/install_base.sh
@@ -121,8 +121,6 @@ else
   rubygems_proxy="https://rubygems.org"
 fi
 
-cd $local_gems
-
 if [ -e /etc/redhat-release ] ; then
 	# needed for rhel >= 7
 	gem update --system 1.8.25


### PR DESCRIPTION
what is the issue 
 with `vendor/cache` now present in `inductor/shared/cookbooks/` we have seen that `require json` gem is failing with error `https://github.com/oneops/circuit-oneops-1.git`. 

it is found that this seems to be an issue with how rubygems behave when `gem install` is run from a directory of .gem files. this behavior is reported at https://github.com/rubygems/rubygems/issues/2170. 

the `cd` into `vendor\cache` directory is removed from the `install_base.sh` to get around this issue.