### PR TITLE
allowing wildcard fqdn on basis of flag

### DIFF
--- a/components/cookbooks/fqdn/libraries/fqdn_base.rb
+++ b/components/cookbooks/fqdn/libraries/fqdn_base.rb
@@ -90,6 +90,18 @@ def get_customer_domain
   return customer_domain
 end #def get_customer_domain
 
+def is_wildcard_enabled(node)
+  if node['workorder'].has_key?('config') && !node['workorder']['config'].empty?
+    config = node['workorder']['config']
+    if config.has_key?('is_wildcard_enabled') && !config['is_wildcard_enabled'].empty? && config['is_wildcard_enabled'] == 'true'
+      return true
+    else
+      return false
+    end
+  end
+  return false
+end
+
 module Fqdn
 
   module Base

--- a/components/cookbooks/fqdn/recipes/build_entries_list.rb
+++ b/components/cookbooks/fqdn/recipes/build_entries_list.rb
@@ -107,13 +107,15 @@ end
 # full aliases uses as-is, cnamed to the platform entry
 full_aliases = Array.new
 if node.workorder.rfcCi.ciAttributes.has_key?("full_aliases") && !is_hostname_entry
+  if node.workorder.rfcCi.ciAttributes.full_aliases =~ /\*/ && !is_wildcard_enabled(node)
+    fail_with_fault "unsupported use of wildcard functinality for this organization"
+  end
   begin
     full_aliases = JSON.parse(node.workorder.rfcCi.ciAttributes.full_aliases)
   rescue Exception =>e
     Chef::Log.info("could not parse full_aliases json: "+node.workorder.rfcCi.ciAttributes.full_aliases)
   end
 end
-
 
 if service_attrs[:cloud_dns_id].nil? || service_attrs[:cloud_dns_id].empty?
   fail_with_fault "no cloud_dns_id for dns cloud service: #{cloud_service[:nsPath]} #{cloud_service[:ciName]}"

--- a/components/cookbooks/fqdn/test/integration/add/serverspec/add_spec.rb
+++ b/components/cookbooks/fqdn/test/integration/add/serverspec/add_spec.rb
@@ -277,6 +277,7 @@ else
     full_aliases.each do |full|
       next if $node['dns_action'] == "delete" && !$node['is_last_active_cloud']
 
+      has_wildcard = $node['workorder']['rfcCi']['ciAttributes']['full_aliases'] =~ /\*/
       full_value = primary_platform_dns_name
       if $node.has_key?("gslb_domain") && !$node['gslb_domain'].nil?
         full_value = $node['gslb_domain']
@@ -292,6 +293,13 @@ else
           expect(result).to include(full_value)
         end
       end
+
+      describe "wildcard entry in FQDN" do
+        it "entry should be enabled" do
+          is_wildcard_enabled = lib.is_wildcard_enabled
+          expect(is_wildcard_enabled).to eq(true)
+        end
+      end if has_wildcard
 
     end
   end

--- a/components/cookbooks/fqdn/test/integration/library.rb
+++ b/components/cookbooks/fqdn/test/integration/library.rb
@@ -154,4 +154,16 @@ class Library
     return [env_name, platform_name, asmb_name, dc_name, ci["ciId"].to_s, "gslbsrvc"].join("-")
   end
 
+  def is_wildcard_enabled
+    if $node['workorder'].has_key?('config') && !$node['workorder']['config'].empty?
+      config = $node['workorder']['config']
+      if config.has_key?('is_wildcard_enabled') && !config['is_wildcard_enabled'].empty? && config['is_wildcard_enabled'] == 'true'
+        return true
+      else
+        return false
+      end
+    end
+    return false
+  end
+
 end

--- a/components/cookbooks/fqdn/test/integration/update/serverspec/update_spec.rb
+++ b/components/cookbooks/fqdn/test/integration/update/serverspec/update_spec.rb
@@ -276,6 +276,7 @@ else
     full_aliases.each do |full|
       next if $node['dns_action'] == "delete" && !$node['is_last_active_cloud']
 
+      has_wildcard = $node['workorder']['rfcCi']['ciAttributes']['full_aliases'] =~ /\*/
       full_value = primary_platform_dns_name
       if $node.has_key?("gslb_domain") && !$node['gslb_domain'].nil?
         full_value = $node['gslb_domain']
@@ -284,13 +285,20 @@ else
       entries.push({:name => full, :values => full_value, :is_hijackable => $node['workorder']['rfcCi']['ciAttributes']['hijackable_full_aliases'] })
       deletable_entries.push({:name => full, :values => full_value})
 
-      context "is_hijackable" do
+      context "full CNAME" do
         it "should exist" do
           command_execute = "host "+full
           result = `#{command_execute}`
           expect(result).to include(full_value)
         end
       end
+
+      describe "wildcard entry in FQDN" do
+        it "entry should be enabled" do
+          is_wildcard_enabled = lib.is_wildcard_enabled
+          expect(is_wildcard_enabled).to eq(true)
+        end
+      end if has_wildcard
 
     end
   end


### PR DESCRIPTION
This is to allow use of wildcard for particular organizations. Orgs which has 'is_wildcard_enabled' flag marked as true can only use wildcard in fqdn.