### PR TITLE
Add OpenStack v3 Auth Support

### DIFF
--- a/components/cookbooks/cinder/recipes/status.rb
+++ b/components/cookbooks/cinder/recipes/status.rb
@@ -6,13 +6,18 @@ require 'fog'
 
 token = node[:workorder][:ci][:ciAttributes]
 
+domain = token.key?('domain') ? token[:domain] : 'default'
+
 conn = Fog::Volume.new({
   :provider => 'OpenStack',
   :openstack_api_key => token[:password],
   :openstack_username => token[:username],
   :openstack_tenant => token[:tenant],
-  :openstack_auth_url => token[:endpoint]
+  :openstack_auth_url => token[:endpoint],
+  :openstack_project_name => token[:domain],
+  :openstack_domain_name => domain
 })
+
 
 limits = conn.get_quota(conn.current_tenant["id"]).body["quota_set"]
 

--- a/components/cookbooks/cinder/recipes/validate.rb
+++ b/components/cookbooks/cinder/recipes/validate.rb
@@ -7,14 +7,17 @@ require 'fog'
 token = node[:workorder][:ci][:ciAttributes]
 
 begin
-conn = Fog::Volume.new({
-  :provider => 'OpenStack',
-  :openstack_api_key => token[:password],
-  :openstack_username => token[:username],
-  :openstack_tenant => token[:tenant],
-  :openstack_auth_url => token[:endpoint]
-})
-Chef::Log.info("credentials ok")
+  conn = Fog::Volume.new({
+    :provider => 'OpenStack',
+    :openstack_api_key => token[:password],
+    :openstack_username => token[:username],
+    :openstack_tenant => token[:tenant],
+    :openstack_auth_url => token[:endpoint],
+    :openstack_project_name => token[:domain],
+    :openstack_domain_name => domain
+  })
+
+  Chef::Log.info("credentials ok")
 
 rescue Exception => e
   Chef::Log.error("credentials bad: #{e.inspect}")

--- a/components/cookbooks/compute/recipes/add_node_openstack.rb
+++ b/components/cookbooks/compute/recipes/add_node_openstack.rb
@@ -25,27 +25,17 @@ Excon.defaults[:write_timeout] = 300
 
 cloud_name = node[:workorder][:cloud][:ciName]
 compute_service = node[:workorder][:services][:compute][cloud_name][:ciAttributes]
+domain = compute_service.key?('domain') ? compute_service[:domain] : 'default'
 
-conn = nil
-
-if compute_service[:endpoint].include?("v3")
-  conn = Fog::Compute.new({
-    :provider => 'OpenStack',
-    :openstack_api_key => compute_service[:password],
-    :openstack_username => compute_service[:username],
-    :openstack_project_name => compute_service[:tenant],
-    :openstack_domain_name => 'default',
-    :openstack_auth_url => compute_service[:endpoint]
-  })  
-else
-  conn = Fog::Compute.new({
-    :provider => 'OpenStack',
-    :openstack_api_key => compute_service[:password],
-    :openstack_username => compute_service[:username],
-    :openstack_tenant => compute_service[:tenant],
-    :openstack_auth_url => compute_service[:endpoint]
-  })
-end
+conn = Fog::Compute.new({
+  :provider => 'OpenStack',
+  :openstack_api_key => compute_service[:password],
+  :openstack_username => compute_service[:username],
+  :openstack_tenant => compute_service[:tenant],
+  :openstack_auth_url => compute_service[:endpoint],
+  :openstack_project_name => compute_service[:tenant],
+  :openstack_domain_name => domain
+})  
 
 rfcCi = node["workorder"]["rfcCi"]
 nsPathParts = rfcCi["nsPath"].split("/")

--- a/components/cookbooks/compute/recipes/add_node_openstack.rb
+++ b/components/cookbooks/compute/recipes/add_node_openstack.rb
@@ -26,14 +26,26 @@ Excon.defaults[:write_timeout] = 300
 cloud_name = node[:workorder][:cloud][:ciName]
 compute_service = node[:workorder][:services][:compute][cloud_name][:ciAttributes]
 
-conn = Fog::Compute.new({
-  :provider => 'OpenStack',
-  :openstack_api_key => compute_service[:password],
-  :openstack_username => compute_service[:username],
-  :openstack_tenant => compute_service[:tenant],
-  :openstack_auth_url => compute_service[:endpoint]
-})
+conn = nil
 
+if compute_service[:endpoint].include?("v3")
+  conn = Fog::Compute.new({
+    :provider => 'OpenStack',
+    :openstack_api_key => compute_service[:password],
+    :openstack_username => compute_service[:username],
+    :openstack_project_name => compute_service[:tenant],
+    :openstack_domain_name => 'default',
+    :openstack_auth_url => compute_service[:endpoint]
+  })  
+else
+  conn = Fog::Compute.new({
+    :provider => 'OpenStack',
+    :openstack_api_key => compute_service[:password],
+    :openstack_username => compute_service[:username],
+    :openstack_tenant => compute_service[:tenant],
+    :openstack_auth_url => compute_service[:endpoint]
+  })
+end
 
 rfcCi = node["workorder"]["rfcCi"]
 nsPathParts = rfcCi["nsPath"].split("/")

--- a/components/cookbooks/compute/test/integration/add/serverspec/openstack_spec.rb
+++ b/components/cookbooks/compute/test/integration/add/serverspec/openstack_spec.rb
@@ -10,14 +10,27 @@ if provider =~ /openstack/i
   nsPathParts = rfcCi['nsPath'].split("/")
   server_name = $node['workorder']['box']['ciName']+'-'+nsPathParts[3]+'-'+nsPathParts[2]+'-'+nsPathParts[1]+'-'+ rfcCi['ciId'].to_s
 
-  # connect to openstack client
-  conn = Fog::Compute.new({
-                              :provider => 'OpenStack',
-                              :openstack_api_key => compute_service['password'],
-                              :openstack_username => compute_service['username'],
-                              :openstack_tenant => compute_service['tenant'],
-                              :openstack_auth_url => compute_service['endpoint']
-                          })
+  conn = nil
+
+  if compute_service[:endpoint].include?("v3")
+    conn = Fog::Compute.new({
+      :provider => 'OpenStack',
+      :openstack_api_key => compute_service[:password],
+      :openstack_username => compute_service[:username],
+      :openstack_project_name => compute_service[:tenant],
+      :openstack_domain_name => 'default',
+      :openstack_auth_url => compute_service[:endpoint]
+    })  
+  else
+    conn = Fog::Compute.new({
+      :provider => 'OpenStack',
+      :openstack_api_key => compute_service[:password],
+      :openstack_username => compute_service[:username],
+      :openstack_tenant => compute_service[:tenant],
+      :openstack_auth_url => compute_service[:endpoint]
+    })
+  end
+
   server = nil
 
   # Find your compute

--- a/components/cookbooks/compute/test/integration/add/serverspec/openstack_spec.rb
+++ b/components/cookbooks/compute/test/integration/add/serverspec/openstack_spec.rb
@@ -9,27 +9,18 @@ if provider =~ /openstack/i
   rfcCi = $node['workorder']['rfcCi']
   nsPathParts = rfcCi['nsPath'].split("/")
   server_name = $node['workorder']['box']['ciName']+'-'+nsPathParts[3]+'-'+nsPathParts[2]+'-'+nsPathParts[1]+'-'+ rfcCi['ciId'].to_s
+  
+  domain = compute_service.key?('domain') ? compute_service[:domain] : 'default'
 
-  conn = nil
-
-  if compute_service[:endpoint].include?("v3")
-    conn = Fog::Compute.new({
-      :provider => 'OpenStack',
-      :openstack_api_key => compute_service[:password],
-      :openstack_username => compute_service[:username],
-      :openstack_project_name => compute_service[:tenant],
-      :openstack_domain_name => 'default',
-      :openstack_auth_url => compute_service[:endpoint]
-    })  
-  else
-    conn = Fog::Compute.new({
-      :provider => 'OpenStack',
-      :openstack_api_key => compute_service[:password],
-      :openstack_username => compute_service[:username],
-      :openstack_tenant => compute_service[:tenant],
-      :openstack_auth_url => compute_service[:endpoint]
-    })
-  end
+  conn = Fog::Compute.new({
+    :provider => 'OpenStack',
+    :openstack_api_key => compute_service[:password],
+    :openstack_username => compute_service[:username],
+    :openstack_tenant => compute_service[:tenant],
+    :openstack_auth_url => compute_service[:endpoint],
+    :openstack_project_name => compute_service[:tenant],
+    :openstack_domain_name => domain
+  })  
 
   server = nil
 

--- a/components/cookbooks/compute/test/integration/delete/serverspec/openstack_spec.rb
+++ b/components/cookbooks/compute/test/integration/delete/serverspec/openstack_spec.rb
@@ -11,13 +11,27 @@ if provider =~ /openstack/i
   server_name = $node[:workorder][:box][:ciName]+'-'+nsPathParts[3]+'-'+nsPathParts[2]+'-'+nsPathParts[1]+'-'+ rfcCi["ciId"].to_s
 
   # connect to openstack client
-  conn = Fog::Compute.new({
-                              :provider => 'OpenStack',
-                              :openstack_api_key => compute_service['password'],
-                              :openstack_username => compute_service['username'],
-                              :openstack_tenant => compute_service['tenant'],
-                              :openstack_auth_url => compute_service['endpoint']
-                          })
+  conn = nil
+
+  if compute_service[:endpoint].include?("v3")
+    conn = Fog::Compute.new({
+      :provider => 'OpenStack',
+      :openstack_api_key => compute_service[:password],
+      :openstack_username => compute_service[:username],
+      :openstack_project_name => compute_service[:tenant],
+      :openstack_domain_name => 'default',
+      :openstack_auth_url => compute_service[:endpoint]
+    })  
+  else
+    conn = Fog::Compute.new({
+      :provider => 'OpenStack',
+      :openstack_api_key => compute_service[:password],
+      :openstack_username => compute_service[:username],
+      :openstack_tenant => compute_service[:tenant],
+      :openstack_auth_url => compute_service[:endpoint]
+    })
+  end
+  
   server = nil
   # Find your compute
   conn.servers.all.each do |i|

--- a/components/cookbooks/compute/test/integration/delete/serverspec/openstack_spec.rb
+++ b/components/cookbooks/compute/test/integration/delete/serverspec/openstack_spec.rb
@@ -11,27 +11,18 @@ if provider =~ /openstack/i
   server_name = $node[:workorder][:box][:ciName]+'-'+nsPathParts[3]+'-'+nsPathParts[2]+'-'+nsPathParts[1]+'-'+ rfcCi["ciId"].to_s
 
   # connect to openstack client
-  conn = nil
+  domain = compute_service.key?('domain') ? compute_service[:domain] : 'default'
 
-  if compute_service[:endpoint].include?("v3")
-    conn = Fog::Compute.new({
-      :provider => 'OpenStack',
-      :openstack_api_key => compute_service[:password],
-      :openstack_username => compute_service[:username],
-      :openstack_project_name => compute_service[:tenant],
-      :openstack_domain_name => 'default',
-      :openstack_auth_url => compute_service[:endpoint]
-    })  
-  else
-    conn = Fog::Compute.new({
-      :provider => 'OpenStack',
-      :openstack_api_key => compute_service[:password],
-      :openstack_username => compute_service[:username],
-      :openstack_tenant => compute_service[:tenant],
-      :openstack_auth_url => compute_service[:endpoint]
-    })
-  end
-  
+  conn = Fog::Compute.new({
+    :provider => 'OpenStack',
+    :openstack_api_key => compute_service[:password],
+    :openstack_username => compute_service[:username],
+    :openstack_tenant => compute_service[:tenant],
+    :openstack_auth_url => compute_service[:endpoint],
+    :openstack_project_name => compute_service[:tenant],
+    :openstack_domain_name => domain
+  })
+    
   server = nil
   # Find your compute
   conn.servers.all.each do |i|

--- a/components/cookbooks/objectstore/recipes/add.rb
+++ b/components/cookbooks/objectstore/recipes/add.rb
@@ -2,6 +2,10 @@ cloud_name = node[:workorder][:cloud][:ciName]
 cloud_type = node[:workorder][:services][:filestore][cloud_name][:ciClassName].split('.').last.downcase
 ciAttr = node[:workorder][:services][:filestore][cloud_name][:ciAttributes]
 
+domain = ciAttr.key('domain') ? ciAttr[:domain] : 'default'
+auth_url = ciAttr[:endpoint].include?('tokens') ? 
+  ciAttr[:endpoint] : "#{ciAttr[:endpoint]}/tokens"
+
 case cloud_type
 when /swift/
   creds = {
@@ -9,8 +13,10 @@ when /swift/
     :openstack_api_key  => ciAttr[:password],
     :openstack_username => ciAttr[:username],
     :openstack_tenant   => ciAttr[:tenant],
-    :openstack_auth_url => ciAttr[:endpoint] + '/tokens',
-    :openstack_region   => ciAttr[:regionname]
+    :openstack_auth_url => auth_url,
+    :openstack_region   => ciAttr[:regionname],
+    :openstack_project_name => ciAttr[:tenant],
+    :openstack_domain_name => domain
   }
 when /azureobjectstore/
   creds = {

--- a/components/cookbooks/openstack/recipes/status.rb
+++ b/components/cookbooks/openstack/recipes/status.rb
@@ -8,26 +8,17 @@ require 'json'
 token = node[:workorder][:ci][:ciAttributes]
 size_map = JSON.parse(token[:sizemap])
 
-conn = nil
+domain = token.key?('domain') ? token[:domain] : 'default'
 
-if compute_service[:endpoint].include?("v3")
 conn = Fog::Compute.new({
   :provider => 'OpenStack',
-  :openstack_api_key => compute_service[:password],
-  :openstack_username => compute_service[:username],
-  :openstack_project_name => compute_service[:tenant],
-  :openstack_domain_name => 'default',
-  :openstack_auth_url => compute_service[:endpoint]
+  :openstack_api_key => token[:password],
+  :openstack_username => token[:username],
+  :openstack_tenant => token[:tenant],
+  :openstack_auth_url => token[:endpoint],
+  :openstack_project_name => token[:tenant],
+  :openstack_domain_name => domain
 })  
-else
-conn = Fog::Compute.new({
-  :provider => 'OpenStack',
-  :openstack_api_key => compute_service[:password],
-  :openstack_username => compute_service[:username],
-  :openstack_tenant => compute_service[:tenant],
-  :openstack_auth_url => compute_service[:endpoint]
-})
-end
 
 limits_all = conn.get_limits.body["limits"]
 

--- a/components/cookbooks/openstack/recipes/status.rb
+++ b/components/cookbooks/openstack/recipes/status.rb
@@ -8,13 +8,26 @@ require 'json'
 token = node[:workorder][:ci][:ciAttributes]
 size_map = JSON.parse(token[:sizemap])
 
+conn = nil
+
+if compute_service[:endpoint].include?("v3")
 conn = Fog::Compute.new({
-                            :provider => 'OpenStack',
-                            :openstack_api_key => token[:password],
-                            :openstack_username => token[:username],
-                            :openstack_tenant => token[:tenant],
-                            :openstack_auth_url => token[:endpoint]
-                        })
+  :provider => 'OpenStack',
+  :openstack_api_key => compute_service[:password],
+  :openstack_username => compute_service[:username],
+  :openstack_project_name => compute_service[:tenant],
+  :openstack_domain_name => 'default',
+  :openstack_auth_url => compute_service[:endpoint]
+})  
+else
+conn = Fog::Compute.new({
+  :provider => 'OpenStack',
+  :openstack_api_key => compute_service[:password],
+  :openstack_username => compute_service[:username],
+  :openstack_tenant => compute_service[:tenant],
+  :openstack_auth_url => compute_service[:endpoint]
+})
+end
 
 limits_all = conn.get_limits.body["limits"]
 

--- a/components/cookbooks/openstack/recipes/validate.rb
+++ b/components/cookbooks/openstack/recipes/validate.rb
@@ -7,14 +7,28 @@ require 'fog'
 token = node[:workorder][:ci][:ciAttributes]
 
 begin
-conn = Fog::Compute.new({
-  :provider => 'OpenStack',
-  :openstack_api_key => token[:password],
-  :openstack_username => token[:username],
-  :openstack_tenant => token[:tenant],
-  :openstack_auth_url => token[:endpoint]
-})
-Chef::Log.info("credentials ok")
+  conn = nil
+
+  if compute_service[:endpoint].include?("v3")
+    conn = Fog::Compute.new({
+      :provider => 'OpenStack',
+      :openstack_api_key => compute_service[:password],
+      :openstack_username => compute_service[:username],
+      :openstack_project_name => compute_service[:tenant],
+      :openstack_domain_name => 'default',
+      :openstack_auth_url => compute_service[:endpoint]
+    })  
+  else
+    conn = Fog::Compute.new({
+      :provider => 'OpenStack',
+      :openstack_api_key => compute_service[:password],
+      :openstack_username => compute_service[:username],
+      :openstack_tenant => compute_service[:tenant],
+      :openstack_auth_url => compute_service[:endpoint]
+    })
+  end
+
+  Chef::Log.info("credentials ok")
 
 rescue Exception => e
   Chef::Log.error("credentials bad: #{e.inspect}")

--- a/components/cookbooks/openstack/recipes/validate.rb
+++ b/components/cookbooks/openstack/recipes/validate.rb
@@ -7,26 +7,17 @@ require 'fog'
 token = node[:workorder][:ci][:ciAttributes]
 
 begin
-  conn = nil
+  domain = token.key?('domain') ? token[:domain] : 'default'
 
-  if compute_service[:endpoint].include?("v3")
-    conn = Fog::Compute.new({
-      :provider => 'OpenStack',
-      :openstack_api_key => compute_service[:password],
-      :openstack_username => compute_service[:username],
-      :openstack_project_name => compute_service[:tenant],
-      :openstack_domain_name => 'default',
-      :openstack_auth_url => compute_service[:endpoint]
-    })  
-  else
-    conn = Fog::Compute.new({
-      :provider => 'OpenStack',
-      :openstack_api_key => compute_service[:password],
-      :openstack_username => compute_service[:username],
-      :openstack_tenant => compute_service[:tenant],
-      :openstack_auth_url => compute_service[:endpoint]
-    })
-  end
+  conn = Fog::Compute.new({
+    :provider => 'OpenStack',
+    :openstack_api_key => token[:password],
+    :openstack_username => token[:username],
+    :openstack_tenant => token[:tenant],
+    :openstack_auth_url => token[:endpoint],
+    :openstack_project_name => token[:tenant],
+    :openstack_domain_name => domain
+  })  
 
   Chef::Log.info("credentials ok")
 


### PR DESCRIPTION
Make sure that v3 auth pass in required :openstack_domain_name.  Right now it is currently set to 'default', but must be configurable in the future.