### PR TITLE
User, volume & diskcleanup jon dependency fixed

### DIFF
--- a/components/cookbooks/zookeeper/recipes/add.rb
+++ b/components/cookbooks/zookeeper/recipes/add.rb
@@ -8,7 +8,9 @@
 
 #Production cloud topology check for prod environments.
 include_recipe "zookeeper::validate_config"
-
+node.set[:zookeeper][:home_dir] = node[:zookeeper][:install_dir]
+node.set[:zookeeper][:exported_jars] = [ ::File.join(node[:zookeeper][:home_dir], "zookeeper.jar"), ]
+Chef::Log.info("exported_jars path = #{node[:zookeeper][:exported_jars]}")
 zk_loc_basename = "#{node[:zookeeper][:version]}"
 zk_basename = "zookeeper-#{node[:zookeeper][:version]}"
 ci = node.workorder.rfcCi.ciAttributes;

--- a/packs/zookeeper.rb
+++ b/packs/zookeeper.rb
@@ -16,7 +16,7 @@ variable "install_dir",
 
 variable "version",
          :description => 'Zookeeper version',
-         :value => '3.4.9'
+         :value => '3.4.6'
 
 resource "secgroup",
          :cookbook => "oneops.1.secgroup",
@@ -279,7 +279,6 @@ resource "jolokia_proxy",
 [
   {:from => 'user-zookeeper', :to => 'volume'},
   {:from => 'volume', :to => 'os'},
-  {:from => 'user-zookeeper', :to => 'volume'},
   {:from => 'user-zookeeper', :to => 'os'},
   {:from => 'zookeeper', :to => 'user-zookeeper'},
   {:from => 'zookeeper', :to => 'os'},

--- a/packs/zookeeper.rb
+++ b/packs/zookeeper.rb
@@ -16,7 +16,7 @@ variable "install_dir",
 
 variable "version",
          :description => 'Zookeeper version',
-         :value => '3.4.6'
+         :value => '3.4.9'
 
 resource "secgroup",
          :cookbook => "oneops.1.secgroup",
@@ -277,7 +277,7 @@ resource "jolokia_proxy",
 
 # depends_on
 [
-  {:from => 'volume', :to => 'user-zookeeper'},
+  {:from => 'user-zookeeper', :to => 'volume'},
   {:from => 'volume', :to => 'os'},
   {:from => 'user-zookeeper', :to => 'os'},
   {:from => 'zookeeper', :to => 'user-zookeeper'},
@@ -288,6 +288,7 @@ resource "jolokia_proxy",
   {:from => 'zookeeper', :to => 'java'},
   {:from => 'java', :to => 'os'},
   {:from => 'diskcleanup-job', :to => 'os'},
+  {:from => 'diskcleanup-job', :to => 'volume'},
   {:from => 'jolokia_proxy', :to => 'java'}
 ].each do |link|
   relation "#{link[:from]}::depends_on::#{link[:to]}",


### PR DESCRIPTION
1. home_dir set to install_dir as it was hard coded as default. And default was not overriden with the configured one.
2. exported_jars overriden with the configured path as it was defaulted with hard coded value
3. Use dependency corrected to be on volume as there was a circular dependency recently added
4. diskcleanup job dependency added on volume so as volume may be configured with user defined mount point which is used on diskcleanup job