### PR TITLE
Fixed a bug KCI compute test for azure clouds.

### DIFF
--- a/components/cookbooks/azure/test/integration/add/serverspec/tests/add.rb
+++ b/components/cookbooks/azure/test/integration/add/serverspec/tests/add.rb
@@ -20,7 +20,7 @@ RSpec.configure do |c|
 end
 
 RSpec.configure do |c|
-  c.filter_run_excluding :custom_image => AzureSpecUtils.new($node).is_imagetypecustom
+  c.filter_run_excluding :custom_image => !AzureSpecUtils.new($node).is_imagetypecustom
 end
 
 describe "azure node::create" do


### PR DESCRIPTION
The filter to exclude custom image test needs to be enabled for non-custom images