### PR TITLE
Fixed issue with KCI tests not failing deployments.

### DIFF
--- a/monkey_patch.rb
+++ b/monkey_patch.rb
@@ -242,3 +242,67 @@ module Kitchen
     end
   end
 end
+
+require 'kitchen/verifier/serverspec'
+
+# Monkey-patching kitchen-verifier-serverspec to use shellout instead of
+# kernel.system, to correctly handle failures, i.e. re-translate exit code.
+# This is fixed in the newer versions of the kitchen-verifier-serverspec gem,
+# but we cannot use them due to different gem dependencies and a gem conflict:
+# kitchen-verifier-serverspec (>0.4.0) depends on net-ssh ~> 3.0
+# and at the same time chef-11.18.12 depends on net-ssh ~> 2.6
+module Kitchen
+  module Verifier
+    # Serverspec verifier for Kitchen.
+    class Serverspec < Kitchen::Verifier::Base
+      def serverspec_commands
+        if config[:remote_exec]
+          if custom_serverspec_command
+            <<-INSTALL
+            #{custom_serverspec_command}
+            INSTALL
+          else
+            <<-INSTALL
+            #{config[:additional_serverspec_command]}
+            mkdir -p #{config[:default_path]}
+            cd #{config[:default_path]}
+            RSPEC_CMD=#{rspec_bash_cmd}
+            echo "---> RSPEC_CMD variable is: ${RSPEC_CMD}"
+            #{rspec_commands}
+            #{remove_default_path}
+            INSTALL
+          end
+        elsif custom_serverspec_command
+          shellout custom_serverspec_command
+        else
+          if config[:additional_serverspec_command]
+            c = config[:additional_serverspec_command]
+            shellout c
+          end
+          c = rspec_commands
+          shellout c
+        end
+      end
+
+      def merge_state_to_env(state)
+        env_state = { :environment => {} }
+        env_state[:environment]['KITCHEN_INSTANCE'] = instance.name
+        env_state[:environment]['KITCHEN_PLATFORM'] = instance.platform.name
+        env_state[:environment]['KITCHEN_SUITE'] = instance.suite.name
+        state.each_pair do |key, value|
+          env_state[:environment]['KITCHEN_' + key.to_s.upcase] = value.to_s
+          ENV['KITCHEN_' + key.to_s.upcase] = value.to_s
+          info("Environment variable #{'KITCHEN_' + key.to_s.upcase} value #{value}")
+        end
+        # if using a driver that uses transport expose those too
+        %w[username password ssh_key port].each do |key|
+          next if instance.transport[key.to_sym].nil?
+          value = instance.transport[key.to_sym].to_s
+          ENV['KITCHEN_' + key.to_s.upcase] = value
+          info("Transport Environment variable #{'KITCHEN_' + key.to_s.upcase} value #{value}")
+        end
+        config[:shellout_opts].merge!(env_state)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The culprit is the kitchen-verifier-serverspec gem that provides the serverspec
verifier for KCI tests that we run on inductors (for compute,lb, fqdn, storage,
etc). That verifier executes rspec command using Kernel.system method and does
not check the exit status.
To fix the issue I monkey-patch the Kitchen::Verifier::Serverspec class, to
replace Kernel.system with MixlibL.shellout.