### PR TITLE
Fixed a bug in KCI test for compute component.

### DIFF
--- a/components/cookbooks/compute/test/integration/add/serverspec/openstack.rb
+++ b/components/cookbooks/compute/test/integration/add/serverspec/openstack.rb
@@ -23,8 +23,15 @@ if provider =~ /openstack/i
   compute_service = $node['workorder']['services']['compute'][cloud_name]['ciAttributes']
   rfcCi = $node['workorder']['rfcCi']
   nsPathParts = rfcCi['nsPath'].split("/")
+
+  # TO-DO incapsulate server_name into a separate function.
+  # Save in a library file and use for both compute recipes and KCI tests
   server_name = $node['workorder']['box']['ciName']+'-'+nsPathParts[3]+'-'+nsPathParts[2]+'-'+nsPathParts[1]+'-'+ rfcCi['ciId'].to_s
-  
+  if(server_name.size > 63)
+    server_name = server_name.slice(0, 63 - rfcCi['ciId'].to_s.size - 1) +
+      '-' + rfcCi['ciId'].to_s
+  end
+
   domain = compute_service.key?('domain') ? compute_service[:domain] : 'default'
 
   conn = Fog::Compute.new({

--- a/components/cookbooks/compute/test/integration/delete/serverspec/openstack.rb
+++ b/components/cookbooks/compute/test/integration/delete/serverspec/openstack.rb
@@ -8,7 +8,14 @@ if provider =~ /openstack/i
   compute_service = $node['workorder']['services']['compute'][cloud_name]['ciAttributes']
   rfcCi = $node["workorder"]["rfcCi"]
   nsPathParts = rfcCi["nsPath"].split("/")
-  server_name = $node[:workorder][:box][:ciName]+'-'+nsPathParts[3]+'-'+nsPathParts[2]+'-'+nsPathParts[1]+'-'+ rfcCi["ciId"].to_s
+
+  # TO-DO incapsulate server_name into a separate function.
+  # Save in a library file and use for both compute recipes and KCI tests
+  server_name = $node['workorder']['box']['ciName']+'-'+nsPathParts[3]+'-'+nsPathParts[2]+'-'+nsPathParts[1]+'-'+ rfcCi['ciId'].to_s
+  if(server_name.size > 63)
+    server_name = server_name.slice(0, 63 - rfcCi['ciId'].to_s.size - 1) +
+      '-' + rfcCi['ciId'].to_s
+  end
 
   # connect to openstack client
   domain = compute_service.key?('domain') ? compute_service[:domain] : 'default'


### PR DESCRIPTION
Server_name (VM name) was determined differently in KCI tests than in actual recipes.
Adjusted the tests.
TO-DO - incapsulate that functionality in a method, save in a lib
make sure all tests and recipes call the library.
Right now we have duplicate code in several places - compute.node_lookup recipe,
azure_base.spec_utils lib, and compute.openstack_spec tests