### PR TITLE
Mixlib-Config Strict Dependency Added in Storage

### DIFF
--- a/components/cookbooks/storage/test/integration/Gemfile
+++ b/components/cookbooks/storage/test/integration/Gemfile
@@ -11,6 +11,7 @@ end
 
 gem 'chefspec', '<=4.7.0'
 gem 'fauxhai', '~>3.6.0'
+gem 'mixlib-config', '2.2.4'
 gem 'chef', '11.18.12'
 gem 'fog', '1.29.0'
 gem 'aws-s3', '0.6.3'


### PR DESCRIPTION
KCI Tests for Storage component are failing because it tries to install the latest version of mixlib-config which has a dependency on Ruby >=2.2 and hence KCI test cases fail before execution. To fix this, a strict dependency of mixlib-config version 2.2.4 has been added in the Kitchen CI Gemfile for Storage.
