### PR TITLE
Fixed a bug with azure volume mount script.

### DIFF
--- a/components/cookbooks/volume/recipes/add.rb
+++ b/components/cookbooks/volume/recipes/add.rb
@@ -178,6 +178,10 @@ EXIT_SUCCESS=0
 EXIT_CRITICAL=2
 IS_FORMATTED=0
 
+swapfile=$(cat /proc/swaps | grep #{initial_mountpoint} | awk '{print $1}')
+if [ $swapfile ]; then
+  swapoff $swapfile
+fi
 umount #{initial_mountpoint}
 pvcreate -f #{ephemeral_device}
 vgcreate #{platform_name}-eph #{ephemeral_device}


### PR DESCRIPTION
If azure agent is configured to put swapfile on /mnt/resource,
that will prevent the mount script from correctly unmounting /mnt/resource.
Fixed by checking for the swapfile and removing it if necessary