### PR TITLE
Refactoring of the network recipe in os cookbook.

### DIFF
--- a/components/cookbooks/os/libraries/network_helper.rb
+++ b/components/cookbooks/os/libraries/network_helper.rb
@@ -1,0 +1,56 @@
+# Helper functions for network recipe
+module NetworkHelper
+  NAMESERVER_CMD = "cat /etc/resolv.conf |grep -v 127 | grep -v '^#' " \
+                   "| grep nameserver | awk '{print $2}'".freeze
+
+  def get_nameservers
+    Mixlib::ShellOut.new(NAMESERVER_CMD).run_command
+                    .stdout.split("\n").join(';')
+  end
+
+  def authoritative_dns(zone_domain)
+    cmd = "dig +short NS #{zone_domain}"
+    Mixlib::ShellOut.new(cmd).run_command.stdout.tr("\n", ' ').strip
+  end
+
+  def authoritative_dns_ip(zone_domain)
+    cmd = "dig +short #{authoritative_dns(zone_domain)}"
+    Mixlib::ShellOut.new(cmd).run_command.stdout.tr("\n", ';').strip
+  end
+
+  def trim_zone_domain(zone_domain)
+    parts = zone_domain.downcase.split('.')
+
+    while parts.size > 2 && authoritative_dns(parts.join('.')).empty?
+      parts = parts.last(parts.size - 1)
+    end
+    parts.join('.')
+  end
+
+  def trim_customer_domain(node)
+    customer_domain = node['customer_domain']
+    customer_domain =~ /^\./ ? customer_domain.slice(0) : customer_domain
+  end
+
+  # Generates 2 lists of search domains - using additional_search_domains
+  # attribute from OS component + customer domain
+  # First list is comma-separated
+  # Second list is space separated with each domain ending with dot
+  #
+  # @param  : chef node object
+  # @return : string comma-separated list of search domains
+  #           string space-separated list of search domains (ending with dot)
+  #
+  def search_domains(node)
+    attr = 'additional_search_domains'.freeze
+    ciAttr = node['workorder']['rfcCi']['ciAttributes']
+    domains_arr = []
+    if ciAttr.key?(attr) && !ciAttr[attr].empty?
+      domains_arr.concat(JSON.parse(ciAttr[attr]))
+    end
+    domains_arr.push(trim_customer_domain(node))
+
+    [domains_arr.join(',').downcase,
+     domains_arr.map { |i| i + '.' }.join(' ').downcase]
+  end
+end

--- a/components/cookbooks/os/templates/default/named.conf.local.erb
+++ b/components/cookbooks/os/templates/default/named.conf.local.erb
@@ -1,0 +1,4 @@
+zone "<%= @zone_domain %>." IN {
+    type forward;
+    forwarders {<%= @forwarders %>};
+};

--- a/components/cookbooks/os/templates/default/named.conf.options.erb
+++ b/components/cookbooks/os/templates/default/named.conf.options.erb
@@ -1,0 +1,7 @@
+options {
+  directory "/var/cache/bind";
+  auth-nxdomain no;    # conform to RFC1035
+  listen-on-v6 { any; };
+  forward only;
+  forwarders { <%= @forwarders.empty? ? '8.8.4.4' : @forwarders %>; };
+};

--- a/components/cookbooks/os/test/integration/add/serverspec/centos_redhat_7.rb
+++ b/components/cookbooks/os/test/integration/add/serverspec/centos_redhat_7.rb
@@ -1,13 +1,16 @@
-# cookbook util
-require '/home/oneops/circuit-oneops-1/components/cookbooks/os/libraries/util'
+# libraries
+OS_PATH = '/home/oneops/circuit-oneops-1/components/cookbooks/os'.freeze
+Dir.glob("#{OS_PATH}/libraries/*.rb").each {|f| require f}
+include NetworkHelper
+
 # Testing util
-require '/home/oneops/circuit-oneops-1/components/cookbooks/os/test/integration/library/util'
+require "#{OS_PATH}/test/integration/library/util"
 
 rfcCi = $node['workorder']['rfcCi']
 host_name = "#{$node['workorder']['box']['ciName']}-#{$node['workorder']['cloud']['ciId']}-#{$node['workorder']['rfcCi']['ciName'].split('-').last.to_i.to_s}-#{rfcCi['ciId']}"
 fqdn_name = "#{host_name}.#{$node['customer_domain']}"
 
-data = YAML::load(File.read("/home/oneops/circuit-oneops-1/components/cookbooks/os/test/integration/add/serverspec/checklist.yml"))
+data = YAML::load(File.read("#{OS_PATH}/test/integration/add/serverspec/checklist.yml"))
 limits = {}
 
 # Directory and file checks
@@ -52,7 +55,7 @@ end
 #--- add-config-files.rb
 
 #--- network.rb
-host_cmd = `hostname -f`
+hostname_from_vm = `hostname -f`.downcase.strip
 
 describe file('/etc/cloud/cloud.cfg') do
   its(:content) { should match /preserve_hostname: true/ }
@@ -68,20 +71,114 @@ end
 
 describe "FQDN" do
   it "Should equal #{fqdn_name.downcase}" do
-    expect(host_cmd.downcase.strip).to be == fqdn_name.downcase.strip
+    expect(hostname_from_vm).to be == fqdn_name.downcase.strip
   end
 end
 
-describe file('/etc/bind/named.conf.options') do
-  its(:content) { should eq get_options_config_string }
+###################################
+#          Bind setup             #
+###################################
+rgx_str = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.)' \
+              '{3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+ip4_regex = Regexp.new(rgx_str)
+zone_domain = trim_zone_domain($node['customer_domain'])
+auth_dns_ip = authoritative_dns_ip(zone_domain).split(';').sort
+
+context 'get_nameservers' do
+  get_nameservers.split(';').each do |ip|
+    describe ip do
+      it 'should be valid ip-address' do
+        expect(ip).to match(ip4_regex)
+      end
+    end
+  end
 end
 
-describe file('/etc/bind/named.conf.local') do
-  its(:content) { should eq get_zone_config_string($node) }
+describe 'trim_zone_domain' do
+  it 'is valid url' do
+    expect("#{zone_domain}.").to match(/(\S+\.)(\1)*/)
+  end
 end
 
-describe file('/etc/dhcp/dhclient.conf') do
-  its(:content) { should eq get_dhcp_config_string($node) }
+context 'authoritative_dns_ip' do
+  auth_dns_ip.each do |ip|
+    describe ip do
+      it 'should be valid ip-address' do
+        expect(ip).to match(ip4_regex)
+      end
+    end
+  end
+end
+
+file_options = '/etc/bind/named.conf.options'
+data_options = File.read(file_options)
+match_options, ips_options = compare_named_conf_options(data_options)
+describe "File #{file_options}" do
+  it 'content matches the template' do
+    expect(match_options).to be true
+  end
+  it 'ips_options are valid' do
+    expect(ips_options.split(';').size).to be >= 1
+  end
+
+  ips_options.split(';').each do |ip|
+    describe "forwarder ip #{ip}" do
+      it 'is a valid ip-address' do
+        expect(ip).to match(ip4_regex)
+      end
+    end
+  end
+end
+
+file_local = '/etc/bind/named.conf.local'
+data_local = File.read(file_local)
+match_local, domain_local, ips_local = compare_named_conf_local(data_local)
+describe "File #{file_local}" do
+  it 'content matches the template' do
+    expect(match_local).to be true
+  end
+  it 'domain_local is valid' do
+    expect(domain_local).to match(/(\S+\.)\1*/)
+  end
+  it 'ips_local are valid' do
+    expect(ips_local.split(';').size).to be >= 1
+  end
+
+  ips_local.split(';').each do |ip|
+    describe "forwarder ip #{ip}" do
+      it 'is a valid ip-address' do
+        expect(ip).to match(ip4_regex)
+      end
+    end
+  end
+end
+
+###################################
+#        dhclient setup           #
+###################################
+file_dhclient = '/etc/dhcp/dhclient.conf'
+data_dhclient = File.read(file_dhclient)
+match_dhclient, customer_domains, hostname = compare_dhclient_conf(data_dhclient)
+describe "File #{file_dhclient}" do
+  it 'content matches the template' do
+    expect(match_dhclient).to be true
+  end
+
+  it 'customer_domains are valid' do
+    expect(customer_domains.split(',').size).to be >= 1
+  end
+
+  customer_domains.split(',').each do |cd|
+    describe cd do
+      it 'is a valid domain' do
+        expect(cd + '.').to match(/(\S+\.)\1*/)
+      end
+    end
+  end
+
+  it 'hostname is valid' do
+    expect(hostname).to match(hostname_from_vm)
+  end
 end
 
 describe command('ls -1 /etc/dhcp/*conf|grep -v dhclient.conf') do

--- a/components/cookbooks/os/test/integration/library/util.rb
+++ b/components/cookbooks/os/test/integration/library/util.rb
@@ -57,7 +57,7 @@ end
 #           string hostname
 #
 def compare_dhclient_conf(data)
-  rgx = /supersede domain-search (\S+)	;
+  rgx = /supersede domain-search (\S+);
 send host-name "(\S+)";/
   match_regex(rgx, data)
 end

--- a/components/cookbooks/os/test/integration/library/util.rb
+++ b/components/cookbooks/os/test/integration/library/util.rb
@@ -1,136 +1,63 @@
 # Testing library
 
-# Mimics file creation of /etc/bind/named.conf.options file from network.rb
+# Matches a string to a regex template
 #
-# @param  : chef node object
-# @return : string file contents
+# @param  : regex template
+#           string file content
+# @return : boolean match?
+#           string first captured group
+#           string second captured group
 #
-def get_options_config_string
-  given_nameserver =(`cat /etc/resolv.conf |grep -v 127  | grep -v '^#' | grep nameserver | awk '{print $2}'`.split("\n")).join(";")
-  options_config =  "options {\n"
-  options_config += "  directory \"/var/cache/bind\";\n";
-  options_config += "  auth-nxdomain no;    # conform to RFC1035\n";
-  options_config += "  listen-on-v6 { any; };\n";
-  options_config += "  forward only;\n"
-  options_config += "  forwarders { "+given_nameserver+"; };\n"
-  options_config += "};\n"
-
-  return options_config
-end
-
-# Mimics file creation of /etc/bind/named.conf.local file from network.rb
-#
-# @param  : chef node object
-# @return : string file contents
-#
-def get_zone_config_string(node)
-  zone_config = ""
-  zone_domain = get_zone_domain(node)
-  
-  authoritative_dns_servers = (`dig +short NS #{zone_domain}`).split("\n")
-  dig_out = `dig +short #{authoritative_dns_servers.join(" ")}`
-  nameservers = dig_out.split("\n")
-  
-  nameservers = compare_forwarders(nameservers)
-  zone_config += "zone \"#{zone_domain+'.'}\" IN {\n"
-  zone_config += "    type forward;\n"
-  zone_config += "    forwarders {"+nameservers.join(";")+";};\n"
-  zone_config += "};\n"
-
-  return zone_config
-end
-
-# Mimics file creation of /etc/dhcp/dhclient.conf file from network.rb
-#
-# @param  : chef node object
-# @return : string file contents
-#
-def get_dhcp_config_string(node)
-  rfcCi = node['workorder']['rfcCi']
-  host_name = "#{node['workorder']['box']['ciName']}-#{node['workorder']['cloud']['ciId']}-#{node['workorder']['rfcCi']['ciName'].split('-').last.to_i.to_s}-#{rfcCi['ciId']}"
-  full_hostname = "#{host_name}.#{node['customer_domain']}"
-  customer_domain = node['customer_domain']
-  given_nameserver =(`cat /etc/resolv.conf |grep -v 127  | grep -v '^#' | grep nameserver | awk '{print $2}'`.split("\n")).join(";")
-  if customer_domain =~ /^\./
-    customer_domain.slice!(0)
-  end
-  customer_domains = ""
-  customer_domains_dot_terminated = ""
-  if node['workorder']['rfcCi']['ciAttributes'].has_key?("additional_search_domains") &&
-      !node['workorder']['rfcCi']['ciAttributes']['additional_search_domains'].empty?
-
-    additional_search_domains = JSON.parse(node['workorder']['rfcCi']['ciAttributes']['additional_search_domains'])
-    additional_search_domains.each do |d|
-      customer_domains += "\"#{d.strip}\","
-      customer_domains_dot_terminated += "#{d.strip}. "
-    end
-  end
-  customer_domains += "\"#{customer_domain}\""
-  customer_domains.downcase!
-
-  
-
-  dhcp_config_content = "supersede domain-search #{customer_domains};\n"
-  dhcp_config_content += "send host-name \"#{full_hostname.downcase}\";\n"
-
-  return dhcp_config_content
-end
-
-# Mimics zone domain gathering operation in network.rb recipe
-#
-# @param  : chef node object
-# @return : string zone domain
-#
-def get_zone_domain(node)
-  node['customer_domain']
-  
-  zone_domain = node['customer_domain'].downcase
-  dns_zone_found = false
-  while !dns_zone_found && zone_domain.split(".").size > 2
-    result = `dig +short NS #{zone_domain}`.to_s
-    
-    valid_result = result.split("\n") - [""]
-    if valid_result.size > 0
-      dns_zone_found = true
-    else
-      parts = zone_domain.split(".")
-      trash = parts.shift
-      zone_domain = parts.join(".")
-    end
-  end
-  
-  return zone_domain
-end
-
-# Checks whether the list of forwarders ip contain the same elements as named servers in any order
-#
-# @param  : namedservers array of ips
-# @return : array namedervers if namedservers matches forwarders in /etc/bind/named.conf.local
-#
-def compare_forwarders(namedservers=[])
-  temp_array = []
-  File.foreach('/etc/bind/named.conf.local') do |line|
-    if line =~ /forwarders/
-      temp = line.strip
-      temp = temp.scan(/(forwarders {[\d,.,;]*})/).last.first
-      temp_array = temp.scan(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
-    end
-  end
-  if namedservers.sort == temp_array.sort
-    return temp_array
+def match_regex(rgx, data)
+  result = rgx.match(data)
+  if result
+    return true, result[1], result[2]
   else
-    return namedservers
+    return false, nil, nil
   end
 end
 
-def get_cloud_environment_vars(node)
+# Compares content of named.conf.options file to the template
+#
+# @param  : string file content
+# @return : boolean match?
+#           string forwarder ips (semicolon-separated)
+#
+def compare_named_conf_options(data)
+  rgx = /options {
+  directory "\/var\/cache\/bind";
+  auth-nxdomain no;    \# conform to RFC1035
+  listen-on-v6 { any; };
+  forward only;
+  forwarders { (\S+) };
+};/
+  match_regex(rgx, data)
+end
 
-  cloud_name = node['workorder']['cloud']['ciName']
-  compute_cloud_service = node['workorder']['services']['compute'][cloud_name]['ciAttributes']
-  env_vars = {}
+# Compares content of named.conf.local file to the template
+#
+# @param  : string file content
+# @return : boolean match?
+#           string domain_zone
+#           string forwarder ips (semicolon-separated)
+#
+def compare_named_conf_local(data)
+  rgx = /zone "(\S+\.)\1*" IN {
+    type forward;
+    forwarders {(\S+)};
+};/
+  match_regex(rgx, data)
+end
 
-  if compute_cloud_service.has_key?("env_vars")
-    env_vars = JSON.parse(compute_cloud_service['env_vars'])
-  end
-  return env_vars
+# Compares content of /etc/dhcp/dhclient.conf file to the template
+#
+# @param  : string file content
+# @return : boolean match?
+#           string customer domains (comma-separated)
+#           string hostname
+#
+def compare_dhclient_conf(data)
+  rgx = /supersede domain-search (\S+)	;
+send host-name "(\S+)";/
+  match_regex(rgx, data)
 end


### PR DESCRIPTION
Removed duplicate functions - in os util library and test util library.
Code cleanup - replacing pure ruby with simple chef resources like file and
template.
Code shared by recipes and kci tests is isolated in functions and moved into a
library.
The main concern was that we had 2 different pieces of code (in the recipe and
in the test library), which would implement the same functionality, just
slightly differently. I tried to re-factor that and to have one implementation
of the functionality (in a library - network_helper.rb), and only have the kci
tests to check the outcome of the function matching the expectation.