### PR TITLE
Removed unnecessary debug messages

### DIFF
--- a/components/cookbooks/compute/recipes/get_ip_from_ci.rb
+++ b/components/cookbooks/compute/recipes/get_ip_from_ci.rb
@@ -24,7 +24,6 @@ ci = node[:workorder][:ci] || node[:workorder][:rfcCi]
 cloud_name = node[:workorder][:cloud][:ciName]
 provider = node[:workorder][:services][:compute][cloud_name][:ciClassName].downcase
 Chef::Log.info("provider :" + provider)
-Chef::Log.info("node :" + node.inspect)
 
 ip = nil
 if provider =~ /openstack|azure/


### PR DESCRIPTION
Along with the recent inductor changes that output of
chef node object can be extremely slow.
Just removing the output