### PR TITLE
Refactored OS component and install_base.

### DIFF
--- a/components/cookbooks/compute/files/default/install_base.sh
+++ b/components/cookbooks/compute/files/default/install_base.sh
@@ -31,6 +31,38 @@ set_env()
     done
 }
 
+set_gem_source()
+{
+  proxy_exists=`gem source | grep $rubygems_proxy | wc -l`
+  if [ $proxy_exists == 0 ] ; then
+    echo "adding $rubygems_proxy to gem sources"
+    gem source --add $rubygems_proxy
+    remove_source http://rubygems.org/
+    remove_source https://rubygems.org/
+  fi
+}
+
+remove_source()
+{
+  gem_source="$1"
+  default_exists=`gem source | grep $gem_source | wc -l`
+  if [ $rubygems_proxy != $gem_source ] && [ $default_exists != 0 ] ; then
+    echo "removing $gem_source from source list"
+    gem source --remove $gem_source
+  fi
+}
+
+downgrade_rubygems()
+{
+  #downgrading rubygems to 1.8.25 because of compatibility issues with rubygems 2.0 and chef 11.4.0
+  #https://discourse.chef.io/t/rubygems-format-loaderror/3677/2
+  rubygems_ver=$((echo "1.8.26" && gem -v) | sort -V | head -n 1)
+  if [ $rubygems_ver == "1.8.26" ]; then
+    echo "Downgrading rubygems..."
+    gem update --system 1.8.25 --no-ri --no-rdoc
+  fi
+}
+
 set_env $@
 
 set -e
@@ -38,9 +70,6 @@ if ! [ -e /etc/ssh/ssh_host_dsa_key ] ; then
   echo "generating host ssh keys"
   /usr/bin/ssh-keygen -A
 fi
-
-# function call
-# get_proxy
 
 # setup os release variables
 echo "Install ruby and bundle."
@@ -67,7 +96,7 @@ elif [ -e /etc/redhat-release ] ; then
   if [ -e /selinux/enforce ]; then
     echo 0 >/selinux/enforce
     echo "SELINUX=disabled" >/etc/selinux/config
-	echo "SELINUXTYPE=targeted" >>/etc/selinux/config
+    echo "SELINUXTYPE=targeted" >>/etc/selinux/config
   fi
 
   # allow ssh sudo's w/out tty
@@ -77,125 +106,84 @@ elif [ -e /etc/redhat-release ] ; then
 
 else
 # debian
-	export DEBIAN_FRONTEND=noninteractive
-	echo "apt-get update ..."
-	apt-get update >/dev/null 2>&1
-	if [ $? != 0 ]; then
-	   echo "apt-get update returned non-zero result code. Usually means some repo is returning a 403 Forbidden. Try deleting the compute from providers console and retrying."
-	   exit 1
-	fi
-	apt-get install -q -y build-essential make libxml2-dev libxslt-dev libz-dev ruby ruby-dev nagios3
-	
-	# seperate rubygems - rackspace 14.04 needs it, aws doesn't
-	set +e
-	apt-get -y -q install rubygems-integration
-	rm -fr /etc/apache2/conf.d/nagios3.conf
-	set -e
+  export DEBIAN_FRONTEND=noninteractive
+  echo "apt-get update ..."
+  apt-get update >/dev/null 2>&1
+  if [ $? != 0 ]; then
+    echo "apt-get update returned non-zero result code. Usually means some repo is returning a 403 Forbidden. Try deleting the compute from providers console and retrying."
+    exit 1
+  fi
+  apt-get install -q -y build-essential make libxml2-dev libxslt-dev libz-dev ruby ruby-dev nagios3
+
+  # seperate rubygems - rackspace 14.04 needs it, aws doesn't
+  set +e
+  apt-get -y -q install rubygems-integration
+  rm -fr /etc/apache2/conf.d/nagios3.conf
+  set -e
 fi
 
 me=`logname`
-base_path="/home/$me"
-
-if [ "$me" == "root" ] ; then
-  base_path="/root"
-fi
-local_gems="$base_path/shared/cookbooks/vendor/cache/"
 
 set +e
-gem source | grep $local_gems
-if [ $? != 0 ]; then
-  gem source --add file://$local_gems
-  gem source --remove 'http://rubygems.org/'
-  gem source
-fi
 
+#set gem source from compute env variable
 if [ -n "$rubygems_proxy" ]; then
-  proxy_exists=`gem source | grep $rubygems_proxy | wc -l`
-  if [ $proxy_exists == 0 ] ; then
-    gem source --remove $rubygems_proxy
-    gem source --remove 'http://rubygems.org/'
-    gem source --remove 'https://rubygems.org/'
-    gem source
-  fi
+  set_gem_source
 else
   rubygems_proxy="https://rubygems.org"
 fi
+mkdir -p -m 755 /opt/oneops
+echo "$rubygems_proxy" > /opt/oneops/rubygems_proxy
 
 if [ -e /etc/redhat-release ] ; then
-	# needed for rhel >= 7
-	gem update --system 1.8.25
-   if [ $? -ne 0 ]; then
-     gem source --remove file://$local_gems
-     gem source --add $rubygems_proxy
-     set -e
-     gem update --system 1.8.25
-     set +e
-   fi	
+  downgrade_rubygems
 fi
 
 gem_version="1.7.7"
 grep 16.04 /etc/issue
-if [ $? -eq 0 ]
-then
+if [ $? -eq 0 ]; then
   gem_version="2.0.2"
 fi
 
-gem install json --version $gem_version --no-ri --no-rdoc
+gem install json --version $gem_version --no-ri --no-rdoc --quiet
 if [ $? -ne 0 ]; then
-    echo "gem install using local repo failed. reverting to rubygems proxy."
-    gem source --remove file://$local_gems
-    gem source --remove 'http://rubygems.org/'
-    gem source --add $rubygems_proxy
-    gem source
-    gem install json --version $gem_version --no-ri --no-rdoc
-    if [ $? -ne 0 ]; then
-      echo "could not install json gem"
-      exit 1
-    fi
+  echo "could not install json gem, version $gem_version"
 fi
 
-set -e
-gem install bundler --bindir /usr/bin --no-ri --no-rdoc
+#set -e
+bundler_installed=$(gem list ^bundler$ -i)
+if [ $bundler_installed != "true" ]; then
+  echo "Installing bundler..."
+  ver=$((echo "1.8.25" && gem -v) | sort -V | head -n 1)
+  if [ $ver != '1.8.25' ]; then
+    gem install bundler -v 1.15.4 --bindir /usr/bin --no-ri --no-rdoc
+  else
+    gem install bundler --bindir /usr/bin --no-ri --no-rdoc
+  fi
+fi
 
-mkdir -p -m 755 /opt/oneops
-echo "$rubygems_proxy" > /opt/oneops/rubygems_proxy
-
-set +e
+#set +e
 perl -p -i -e 's/ 00:00:00.000000000Z//' /var/lib/gems/*/specifications/*.gemspec 2>/dev/null
 
 # oneops user
 grep "^oneops:" /etc/passwd 2>/dev/null
 if [ $? != 0 ] ; then
-    set -e
-	echo "*** ADD oneops USER ***"
+  set -e
+  echo "*** ADD oneops USER ***"
 
-	# create oneops user & group - deb systems use addgroup
-	if [ -e /etc/lsb-release] ] ; then
-		addgroup oneops
-	else
-		groupadd oneops
-	fi
+  # create oneops user & group - deb systems use addgroup
+  if [ -e /etc/lsb-release] ] ; then
+    addgroup oneops
+  else
+    groupadd oneops
+  fi
 
-	useradd oneops -g oneops -m -s /bin/bash
-	echo "oneops   ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers
+  useradd oneops -g oneops -m -s /bin/bash
+  echo "oneops   ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers
 else
-	echo "oneops user already there..."
+  echo "oneops user already there..."
 fi
 
-echo "Gem settings for oneops user. ruby gem source is $rubygems_proxy"
-su - oneops <<EOF
-for ARG in "$@"
-do
-    $(set_env $@)
-done
-if [ -n "$rubygems_proxy" ]; then
-    gem source --remove 'http://rubygems.org/'
-    gem source --remove 'https://rubygems.org/'
-    gem source --add $rubygems_proxy
-    gem source
-fi
-set -e
-EOF
 set -e
 
 # ssh and components move
@@ -218,7 +206,9 @@ if [ -e /etc/SuSE-release ] ; then
   me_group="users"
 fi
 
-pwd
+# Configure gem sources for oneops user
+\cp ~/.gemrc /home/oneops/
+
 # gets rid of the 'only use ec2-user' ssh response
 sed -e 's/.* ssh-rsa/ssh-rsa/' .ssh/authorized_keys > .ssh/authorized_keys_
 mv .ssh/authorized_keys_ .ssh/authorized_keys
@@ -239,8 +229,6 @@ if [ "$me" == "idcuser" ] ; then
   openssl rand -base64 12 | passwd oneops --stdin
 fi
 
-rsync -a $home_dir/circuit-oneops-1 /home/oneops/
-rsync -a $home_dir/shared /home/oneops/
 mkdir -p -m 750 /etc/nagios/conf.d
 mkdir -p -m 755 /opt/oneops/workorder
 mkdir -p -m 750 /var/log/nagios

--- a/components/cookbooks/compute/files/default/install_fastimage_base.sh
+++ b/components/cookbooks/compute/files/default/install_fastimage_base.sh
@@ -37,10 +37,6 @@ else
   `cp ~/.ssh/authorized_keys /home/oneops/.ssh/authorized_keys`
 fi
 
-
-# rsync cookbooks
-rsync -a $home_dir/circuit-oneops-1 /home/oneops/
-rsync -a $home_dir/shared /home/oneops/
 chown -R oneops:oneops /home/oneops/circuit-oneops-1 /home/oneops/shared /home/oneops/.ssh /opt/oneops/workorder /opt/oneops/rubygems_proxy
 
 # Setup path

--- a/components/cookbooks/compute/recipes/get_ip_from_ci.rb
+++ b/components/cookbooks/compute/recipes/get_ip_from_ci.rb
@@ -12,26 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ci = node[:workorder][:ci] || node[:workorder][:rfcCi]
-
 if node.has_key?("ip")
   Chef::Log.info("using ip: #{node[:ip]}")
   return
 end
 
-ci = node[:workorder][:ci] || node[:workorder][:rfcCi]
-
-cloud_name = node[:workorder][:cloud][:ciName]
-provider = node[:workorder][:services][:compute][cloud_name][:ciClassName].downcase
-Chef::Log.info("provider :" + provider)
-
-ip = nil
-if provider =~ /openstack|azure/
-  ip = ci[:ciAttributes][:private_ip] || ci[:ciAttributes][:public_ip]
-else
-  ip = ci[:ciAttributes][:public_ip]
-end
-# once inductor ActionOrderExecutor is released with change to populate node[:ip_attribute] we can move to:
-# node.set[:ip] = ci[:ciAttributes][node[:ip_attribute]]
-
-node.set[:ip] = ip
+ci = node['workorder']['ci'] || node['workorder']['rfcCi']
+node.set['ip'] = ci['ciAttributes'][node['ip_attribute']]

--- a/components/cookbooks/os/libraries/network_helper.rb
+++ b/components/cookbooks/os/libraries/network_helper.rb
@@ -4,8 +4,8 @@ module NetworkHelper
                    "| grep nameserver | awk '{print $2}'".freeze
 
   def get_nameservers
-    Mixlib::ShellOut.new(NAMESERVER_CMD).run_command
-                    .stdout.split("\n").join(';')
+    Mixlib::ShellOut.new(NAMESERVER_CMD).run_command.
+    stdout.split("\n").join(';')
   end
 
   def authoritative_dns(zone_domain)


### PR DESCRIPTION
There are couple of reasons for re-factoring:
1) As a prerequisite for incoming changes to support CentOs 6.9
2) Install_base was trying to install gems from local cache, but the implementation 
was wrong, so it never was able to do that, and would always fall back to fetching
gems from remote repo. I just remove that logic for local install. Do not confuse
this with local gem installation that happens with exec-order.rb. Exec-order.rb still
uses local cache. And install_base only installs 2 gems - json and bundler.
3) To fix an issue with fast-image enabled clouds and windows deployments
4) To speed up deployment by removing unnecessary rsync of circuits for root