### PR TITLE
Fixed an issue with nodetool_repair platform procedure.

### DIFF
--- a/packs/apache_cassandra.rb
+++ b/packs/apache_cassandra.rb
@@ -598,7 +598,7 @@ procedure "nodetool_repair",
                     "relationName": "base.RealizedAs",
                     "execStrategy": "one-by-one",
                     "direction": "from",
-                    "targetClassName": "bom.walmartlabs.Apache_cassandra",
+                    "targetClassName": "bom.oneops.1.Apache_cassandra",
                     "actions": [
                         {
                             "actionName": "nodetool_repair",


### PR DESCRIPTION
Its definition was still referencing walmartlabs bom class.
Changed to oneops.1