### PR TITLE
Fixed bug with missing search domains in /etc/resolv.conf.

### DIFF
--- a/components/cookbooks/os/libraries/network_helper.rb
+++ b/components/cookbooks/os/libraries/network_helper.rb
@@ -50,7 +50,7 @@ module NetworkHelper
     end
     domains_arr.push(trim_customer_domain(node))
 
-    [domains_arr.join(',').downcase,
+    [domains_arr.map{|i| '"' + i + '"'}.join(',').downcase,
      domains_arr.map { |i| i + '.' }.join(' ').downcase]
   end
 end

--- a/components/cookbooks/os/test/integration/add/serverspec/centos_redhat_7.rb
+++ b/components/cookbooks/os/test/integration/add/serverspec/centos_redhat_7.rb
@@ -171,7 +171,7 @@ describe "File #{file_dhclient}" do
   customer_domains.split(',').each do |cd|
     describe cd do
       it 'is a valid domain' do
-        expect(cd + '.').to match(/(\S+\.)\1*/)
+        expect(cd + '.').to match(/"(\S+\.)\1*\S+"/)
       end
     end
   end


### PR DESCRIPTION
During the latest re-factoring double quotes around search domains in
/etc/dhcp/dhclient.conf were mistakenly removed. Putting them back.