### PR TITLE
Fixed Apache Cassandra spec_helper.rb path in kitchen test

### DIFF
--- a/components/cookbooks/apache_cassandra/test/integration/add/serverspec/add_spec.rb
+++ b/components/cookbooks/apache_cassandra/test/integration/add/serverspec/add_spec.rb
@@ -1,9 +1,8 @@
-CIRCUIT_PATH="/opt/oneops/inductor/circuit-oneops-1"
+is_windows = ENV['OS'] == 'Windows_NT'
+CIRCUIT_PATH = "#{is_windows ? 'C:/Cygwin64' : ''}/home/oneops/circuit-oneops-1"
 COOKBOOKS_PATH="#{CIRCUIT_PATH}/components/cookbooks"
 
 require "#{CIRCUIT_PATH}/components/spec_helper.rb"
-require "#{COOKBOOKS_PATH}/azure_base/test/integration/azure_spec_utils"
-
 
 #run the tests
 tsts = File.expand_path("tests", File.dirname(__FILE__))

--- a/components/cookbooks/apache_cassandra/test/integration/add/serverspec/tests/add.rb
+++ b/components/cookbooks/apache_cassandra/test/integration/add/serverspec/tests/add.rb
@@ -1,5 +1,3 @@
-require "#{$circuit_path}/circuit-oneops-1/components/spec_helper.rb"
-
 describe user('cassandra') do
     it { should exist }
 end


### PR DESCRIPTION
It appears that whoever wrote this test just copied in the code from azure tests not knowing that Apache Cassandra test cases run on remote while the azure tests run on inductor. The spec_helper.rb is at different locations for both. 