### PR TITLE
Fix Availability Set Issue in Storage Add Recipe

### DIFF
--- a/components/cookbooks/storage/recipes/add.rb
+++ b/components/cookbooks/storage/recipes/add.rb
@@ -192,15 +192,7 @@ Array(1..slice_count).each do |i|
       Utils.set_proxy(node[:workorder][:payLoad][:OO_CLOUD_VARS])
 
       rg_manager = AzureBase::ResourceGroupManager.new(node)
-      av_name = nil;
-
-      is_new_cloud = Utils.is_new_cloud(node)
-
-      if is_new_cloud
-        av_manager = AzureBase::AvailabilitySetManager.new($node)
-        av_name = av_manager.get_availability_set_name
-      else
-        av_name = rg_manager.rg_name
+      as_manager = AzureBase::AvailabilitySetManager.new(node)
 
       compute_attr = node[:workorder][:payLoad][:DependsOn].select{|d| (d[:ciClassName].split('.').last == 'Compute') }.first[:ciAttributes]
       vm = node[:storage_provider].servers(:resource_group => rg_manager.rg_name).get(rg_manager.rg_name, compute_attr[:instance_name])
@@ -212,7 +204,7 @@ Array(1..slice_count).each do |i|
       end
       vol_name = rfcCi[:ciName] + '-' + rfcCi[:ciId].to_s + '-' + dev.split('/').last.to_s
 
-      availability_set_response = node[:storage_provider].availability_sets.get(rg_manager.rg_name, av_name)
+      availability_set_response = node[:storage_provider].availability_sets.get(rg_manager.rg_name, as_manager.as_name)
 
       if availability_set_response.sku_name == 'Aligned'
         volume = node.storage_provider.managed_disks.create(
@@ -247,7 +239,6 @@ Array(1..slice_count).each do |i|
     end
     volume = node.storage_provider.volumes.new :device => dev, :size => slice_size, :availability_zone => avail_zone
   end
-
 
   if node.storage_provider_class !~ /azuredatadisk/
     volume_dev = volume.id.to_s + ':' + dev

--- a/components/cookbooks/storage/test/integration/storage_helper.rb
+++ b/components/cookbooks/storage/test/integration/storage_helper.rb
@@ -23,5 +23,6 @@ if $storage_provider_class =~ /azuredatadisk/
   Dir["#{$circuit_path}/circuit-oneops-1/components/cookbooks/azure_base/libraries/*.rb"].each {|file| require file }
   Utils.set_proxy($node['workorder']['payLoad']['OO_CLOUD_VARS'])
   $resource_group_name = AzureBase::ResourceGroupManager.new($node).rg_name
+  $availability_set_name = AzureBase::AvailabilitySetManager.new($node).as_name
   $storage_service = $storage_provider.instance_variable_get('@storage_service')
 end

--- a/components/cookbooks/storage/test/integration/storage_spec.rb
+++ b/components/cookbooks/storage/test/integration/storage_spec.rb
@@ -3,7 +3,7 @@ require "#{$circuit_path}/circuit-oneops-1/components/spec_helper.rb"
 require "#{File.dirname(__FILE__)}/storage_helper"
 
 if $storage_provider_class =~ /azuredatadisk/
-  availability_set_response = $storage_provider.availability_sets.get($resource_group_name, $resource_group_name)
+  availability_set_response = $storage_provider.availability_sets.get($resource_group_name, $availability_set_name)
 
   describe 'Azure managed data disks' do
     let (:managed_disks) {$storage_provider.list_managed_disks_by_rg($resource_group_name).select{ |md| (md.os_type.nil?)}}


### PR DESCRIPTION
`storage::add.rb` recipe was using resource group's name as availability set's name to get the availability set for data disk's creation. 
However for the new Azure subscription design, resource group's name can be different from availability set's name depending on whether it is an old cloud or new cloud. Hence new code has been added to get availability set's name directly from `AvailabilitySetManager` class instead of using resource group's name.

KCI tests have been updated as well.