### PR TITLE
Fix an error that happens during Spark master replacements

### DIFF
--- a/components/cookbooks/hadoop-yarn-v1/recipes/ssh.rb
+++ b/components/cookbooks/hadoop-yarn-v1/recipes/ssh.rb
@@ -52,7 +52,15 @@ bash "generate ssh_known_hosts" do
     user "root"
     cwd "/etc/ssh"
     code <<-EOF
-        /usr/bin/ssh-keyscan #{fqdns_joined} > /etc/ssh/ssh_known_hosts
+        #/usr/bin/ssh-keyscan #{fqdns_joined} > /etc/ssh/ssh_known_hosts
+        echo "" > /etc/ssh/ssh_known_hosts
+        for fqdn in "#{fqdns_joined}"; do
+            getent hosts $fqdn >dev/null 2>/dev/null
+            # Scan the key if this is a valid FQDN
+            if [[ "$?" == "0" ]]; then
+                ssh-keyscan $fqdn >> /etc/ssh/ssh_known_hosts
+            fi
+        done
     EOF
 end
 


### PR DESCRIPTION
ssh-keyscan was erroring out during a Spark master replace.  Added resiliency to check for valid DNS hosts before scanning their keys.