### PR TITLE
Added support for custom attributes for netscaler monitors.

### DIFF
--- a/components/cookbooks/netscaler/README.md
+++ b/components/cookbooks/netscaler/README.md
@@ -32,3 +32,19 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+# Configuring custom attributes for netscaler monitor
+Example: we have this listener: `tcp 5432 tcp 5432`
+(external protocol - external port - internal protocol - internal port)
+
+Monitors are mapped to listeners by using internal port.
+To configure monitors we use `ecv_map` attribute of the lb component, which is a hash.
+Name part of the hash is internal port, value part is the request.
+So the basic tcp monitor for the above mentioned listener would be:
+`5432` => `get /foo/bar`
+
+To configure custom monitor settings we can use the following format:
+`port|attribute_name` => `attribute_value`.
+For example, to configure an http monitor for the above mentioned listener we should add these entries:
+* `5432|type` => `HTTP`
+* `5432|httprequest` => `GET /foo/bar`

--- a/components/cookbooks/netscaler/recipes/add_monitor.rb
+++ b/components/cookbooks/netscaler/recipes/add_monitor.rb
@@ -101,7 +101,9 @@ node.monitors.each do |mon|
   monitor_name = mon[:monitor_name]
 
   #monitor_type
-  if ['UDP','TCP'].include?(protocol)
+  if monitor_attrs.has_key(:type)
+    monitor_type =  monitor_attrs[:type]
+  elsif ['UDP','TCP'].include?(protocol)
     monitor_type =  protocol
   elsif protocol == 'MSSQL'
     monitor_type =  'MSSQL-ECV'
@@ -124,11 +126,15 @@ node.monitors.each do |mon|
   }
 
   #Adding protocol-specific attributes
-  if monitor_type == 'HTTP'
-    monitor.merge!({:respcode => ['200'], :httprequest => ecv})
-  else
-    monitor.merge!(monitor_attrs)
+  if monitor_type == 'HTTP' && !monitor_attrs.has_key(:respcode)
+    monitor.merge!({ :respcode => ['200'] }
   end
+
+  if monitor_type == 'HTTP' && !monitor_attrs.has_key(:httprequest)
+    monitor.merge!({ :httprequest => ecv })
+  end
+
+  monitor.merge!(monitor_attrs)
 
   # cleanup previous az
   if node.has_key?("ns_conn_prev")

--- a/components/cookbooks/netscaler/recipes/get_monitor_name.rb
+++ b/components/cookbooks/netscaler/recipes/get_monitor_name.rb
@@ -51,9 +51,20 @@ iport_map.each_pair do |iport,protocol|
     base_monitor_name = lb_ci_id + "-"+ iport +"-monitor"
   end
 
+  #get custom attributes applicable to this particular monitor
+  monitor_attrs = {}
+  char = '|'
+  ecv_map.each_pair do |n,v|
+    if n.split(char).size == 2 && n.split(char)[0].to_s == iport.to_s
+      monitor_attrs[n.split(char).last] = v
+    end
+  end
+
   monitor_request = 'get /'
   if ecv_map.has_key?(iport)
     monitor_request = ecv_map[iport].downcase
+  elsif monitor_attrs.size > 0
+    monitor_request = monitor_attrs.values.first
   end
 
   # use generic monitors


### PR DESCRIPTION
Provides an ability to specify multiple custom attributes for each monitor,
by using port|attr_name => attr_value syntax in ecv_map attribute of lb component.