### PR TITLE
Replaced exit command with return.

### DIFF
--- a/components/cookbooks/lb/recipes/bind_cloud.rb
+++ b/components/cookbooks/lb/recipes/bind_cloud.rb
@@ -34,7 +34,7 @@ end
 
 if cloud_service[:ciClassName] !~ /netscaler|f5/i
   Chef::Log.info("lb cloud service is #{cloud_service} but this action is only supported for netscaler Or F5-BigIP cloud service hence exiting...")
-  exit 0
+  return
 end
 
 #include_recipe "lb::get_lb_name"

--- a/components/cookbooks/lb/recipes/unbind_cloud.rb
+++ b/components/cookbooks/lb/recipes/unbind_cloud.rb
@@ -34,7 +34,7 @@ end
 
 if cloud_service[:ciClassName] !~ /netscaler|f5/i
   Chef::Log.info("lb cloud service is #{cloud_service} but this action is only supported for netscaler Or F5-BigIP cloud service hence exiting...")
-  exit 0
+  return
 end
 
 #include_recipe "lb::get_lb_name"


### PR DESCRIPTION
Unlike ruby, chef still raises an exception if we try to exit a recipe with 'exit 0' command.
A quick workaround would be to use 'return' instead