### PR TITLE
enable option ecs to ENABLED by default for gslb_vserver

### DIFF
--- a/components/cookbooks/netscaler/providers/gslb_vserver.rb
+++ b/components/cookbooks/netscaler/providers/gslb_vserver.rb
@@ -147,7 +147,8 @@ def create_gslb_vserver
         :name => gslb_vserver_name,
         :dnsrecordtype => @new_resource.dnsrecordtype,
         :servicetype =>  @new_resource.servicetype,
-        :lbmethod => @new_resource.lbmethod
+        :lbmethod => @new_resource.lbmethod,
+        :ecs => "ENABLED"
     }
 
     req = 'object= { "gslbvserver":'+JSON.dump(gslb_vserver)+'}'


### PR DESCRIPTION
Enable option ecs to ENABLED by default instead of DISABLED.  This is just a placeholder to get the work started.