### PR TITLE
Added support for json content in ecv_map attribute, lb component.

### DIFF
--- a/components/cookbooks/azure_base/test/integration/azure_lb_spec_utils.rb
+++ b/components/cookbooks/azure_base/test/integration/azure_lb_spec_utils.rb
@@ -9,16 +9,7 @@ class AzureLBSpecUtils < AzureSpecUtils
 
     lb_name
   end
-  def get_probes
-    probes = []
-    ecvs = AzureNetwork::LoadBalancer.get_probes_from_wo(@node)
 
-    ecvs.each do |ecv|
-      probe = AzureNetwork::LoadBalancer.create_probe(ecv[:probe_name], ecv[:protocol], ecv[:port], ecv[:interval_secs], ecv[:num_probes], ecv[:request_path])
-      probes.push(probe)
-    end
-    probes
-  end
   def get_loadbalancer_rules(subscription_id, resource_group_name, lb_name, env_name, platform_name, probes, frontend_ipconfig_id, backend_address_pool_id)
     lb_rules = []
 

--- a/components/cookbooks/azure_lb/recipes/add.rb
+++ b/components/cookbooks/azure_lb/recipes/add.rb
@@ -13,21 +13,6 @@ def create_publicip(cred_hash, location, resource_group_name)
   pip
 end
 
-def get_probes(ecvs)
-  probes = []
-
-  ecvs.each do |ecv|
-    probe = AzureNetwork::LoadBalancer.create_probe(ecv[:probe_name], ecv[:protocol], ecv[:port], ecv[:interval_secs], ecv[:num_probes], ecv[:request_path])
-    OOLog.info("Probe name: #{ecv[:probe_name]}")
-    OOLog.info("Probe protocol: #{ecv[:protocol]}")
-    OOLog.info("Probe port: #{ecv[:port]}")
-    OOLog.info("Probe path: #{ecv[:request_path]}")
-    probes.push(probe)
-  end
-
-  probes
-end
-
 def get_listeners_from_wo
   listeners = Array.new
 
@@ -239,7 +224,7 @@ backend_address_pools.push(backend_address_pool_name)
 backend_address_pool_ids.push(backend_address_pool_id)
 
 # ECV/Probes
-probes = get_probes(work_order_utils.ecvs)
+probes = work_order_utils.ecvs
 
 # Listeners/LB Rules
 lb_rules = get_loadbalancer_rules(subscription_id, resource_group_name, lb_name, env_name, platform_name, work_order_utils.listeners, probes, frontend_ipconfig_id, backend_address_pool_id, work_order_utils.load_distribution)

--- a/components/cookbooks/azure_lb/spec/load_balancer_spec.rb
+++ b/components/cookbooks/azure_lb/spec/load_balancer_spec.rb
@@ -131,13 +131,6 @@ describe AzureNetwork::LoadBalancer do
     end
   end
 
-  describe '#create_probe' do
-    it 'creates probe successfully' do
-      probe = AzureNetwork::LoadBalancer.create_probe('Test-probe', 'Tcp', 8080, 5, 16, 'myprobeapp1/myprobe1.svc')
-      expect(probe[:name]).to eq('Test-probe')
-    end
-  end
-
   describe '#create_lb_rule' do
     it 'creates lb rule successfully' do
       probe_id = '/subscriptions/{guid}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/myLB1/probes/Test-Probe'
@@ -158,7 +151,7 @@ describe AzureNetwork::LoadBalancer do
 
   describe '#get_lb' do
     it 'gets load balancer hash successfully' do
-      lb = AzureNetwork::LoadBalancer.get_lb('Test-LB-RG', 'Test-LB', 'eastus', 'frontend_ip_configs', 'backend_address_pools', 'lb_rules', 'nat_rules', 'probes')
+      lb = AzureNetwork::LoadBalancer.get_lb('Test-LB-RG', 'Test-LB', 'eastus', 'frontend_ip_configs', 'backend_address_pools', 'lb_rules', 'nat_rules', 'probes', 'tags')
       expect(lb[:name]).to eq('Test-LB')
     end
   end

--- a/components/cookbooks/azure_lb/test/integration/add/serverspec/tests/add.rb
+++ b/components/cookbooks/azure_lb/test/integration/add/serverspec/tests/add.rb
@@ -95,26 +95,6 @@ describe 'azure lb' do
       end
     end
 
-    it 'protocol is set to backend protocol of a matching listener' do
-      listeners_from_wo = @work_order_utils.listeners
-
-      lb_svc = AzureNetwork::LoadBalancer.new(@spec_utils.get_azure_creds)
-      load_balancer = lb_svc.get(@spec_utils.get_resource_group_name, @spec_utils.get_lb_name)
-      probes = load_balancer.probes
-
-      probes.each do |p|
-        listener = listeners_from_wo.detect {|l| l[:iport].to_i == p.port}
-
-        if !listener.nil?
-          expected_probe_protocol = 'http'
-          if listener[:iprotocol].downcase == 'https' || listener[:iprotocol].downcase == 'tcp'
-            expected_probe_protocol = 'tcp'
-          end
-          expect(p.protocol.downcase).to eq(expected_probe_protocol)
-        end
-      end
-    end
-
   end
 
   context 'listeners' do

--- a/components/cookbooks/azure_lb/test/integration/add/serverspec/tests/add.rb
+++ b/components/cookbooks/azure_lb/test/integration/add/serverspec/tests/add.rb
@@ -79,21 +79,6 @@ describe 'azure lb' do
   end
 
   context 'probes' do
-    it 'protocol is set to http when there is no listener with same backend port' do
-      listeners_from_wo = @work_order_utils.listeners
-
-      lb_svc = AzureNetwork::LoadBalancer.new(@spec_utils.get_azure_creds)
-      load_balancer = lb_svc.get(@spec_utils.get_resource_group_name, @spec_utils.get_lb_name)
-      probes = load_balancer.probes
-
-      probes.each do |p|
-        listener = listeners_from_wo.detect {|l| l[:iport].to_i == p.port}
-        if listener.nil?
-          expect(p.protocol.downcase).to eq('http')
-        end
-      end
-    end
-
     it 'protocol is set to tcp for a matching https listener' do
       listeners_from_wo = @work_order_utils.listeners
 
@@ -144,83 +129,6 @@ describe 'azure lb' do
         expect(az_lb_rule.probe_id).not_to be_empty
       end
     end
-
-    context 'http listener' do
-      it 'uses a http probe' do
-        listeners_from_wo = @work_order_utils.listeners
-        lb_svc = AzureNetwork::LoadBalancer.new(@spec_utils.get_azure_creds)
-        load_balancer = lb_svc.get(@spec_utils.get_resource_group_name, @spec_utils.get_lb_name)
-
-        listeners_from_wo.each do |l|
-          if l[:iprotocol].downcase == 'http'
-            az_lb_rule = load_balancer.load_balancing_rules.detect {|r| r.frontend_port.to_i == l[:vport].to_i}
-            az_lb_rule_probe_name = Hash[*(az_lb_rule.probe_id.split('/'))[1..-1]]['probes']
-            az_lb_rule_probe = load_balancer.probes.detect {|p| p.name == az_lb_rule_probe_name}
-
-            expect(az_lb_rule_probe.protocol.downcase == 'http')
-          end
-        end
-      end
-
-      it 'uses any http probe when a probe with same port is not found' do
-        lb_svc = AzureNetwork::LoadBalancer.new(@spec_utils.get_azure_creds)
-        load_balancer = lb_svc.get(@spec_utils.get_resource_group_name, @spec_utils.get_lb_name)
-
-        listeners_from_wo = @work_order_utils.listeners
-        ecvs_from_wo = @work_order_utils.ecvs
-
-        listeners_from_wo.each do |l|
-          if l[:iprotocol].downcase == 'http'
-            ecv = ecvs_from_wo.detect {|ecv| ecv[:port].to_i == l[:iport].to_i}
-            if ecv.nil?
-              az_lb_rule = load_balancer.load_balancing_rules.detect {|r| r.frontend_port.to_i == l[:vport].to_i}
-              az_lb_rule_probe_name = Hash[*(az_lb_rule.probe_id.split('/'))[1..-1]]['probes']
-              az_lb_rule_probe = load_balancer.probes.detect {|p| p.name == az_lb_rule_probe_name}
-
-              expect(az_lb_rule_probe).not_to be_nil
-              expect(az_lb_rule_probe.protocol.downcase).to eq('http')
-            end
-          end
-        end
-      end
-    end
-
-    context 'tcp listener' do
-      it 'uses a tcp probe' do
-        listeners_from_wo = @work_order_utils.listeners
-        lb_svc = AzureNetwork::LoadBalancer.new(@spec_utils.get_azure_creds)
-        load_balancer = lb_svc.get(@spec_utils.get_resource_group_name, @spec_utils.get_lb_name)
-
-        listeners_from_wo.each do |l|
-          if l[:iprotocol].downcase == 'tcp'
-            az_lb_rule = load_balancer.load_balancing_rules.detect {|r| r.frontend_port.to_i == l[:vport].to_i}
-            az_lb_rule_probe_name = Hash[*(az_lb_rule.probe_id.split('/'))[1..-1]]['probes']
-            az_lb_rule_probe = load_balancer.probes.detect {|p| p.name == az_lb_rule_probe_name}
-
-            expect(az_lb_rule_probe.protocol.downcase == 'tcp')
-          end
-        end
-      end
-    end
-
-    context 'https listener' do
-      it 'uses a tcp probe' do
-        listeners_from_wo = @work_order_utils.listeners
-        lb_svc = AzureNetwork::LoadBalancer.new(@spec_utils.get_azure_creds)
-        load_balancer = lb_svc.get(@spec_utils.get_resource_group_name, @spec_utils.get_lb_name)
-
-        listeners_from_wo.each do |l|
-          if l[:iprotocol].downcase == 'https'
-            az_lb_rule = load_balancer.load_balancing_rules.detect {|r| r.frontend_port.to_i == l[:vport].to_i}
-            az_lb_rule_probe_name = Hash[*(az_lb_rule.probe_id.split('/'))[1..-1]]['probes']
-            az_lb_rule_probe = load_balancer.probes.detect {|p| p.name == az_lb_rule_probe_name}
-
-            expect(az_lb_rule_probe.protocol.downcase == 'tcp')
-          end
-        end
-      end
-    end
-
   end
 
 end


### PR DESCRIPTION
The value part of ecv_map hash can now use json content, which may be an array
of health probes, or a hash of a single health probe. This way we can specify
non-default values for a hash probe.
Also we now can use a health probe with a different protocol (and port) as
compared to one the LB rule has. Unit and integration tests have been adjusted
to reflect the change in functionality.
Multiple health probes can be specified per LB rule but only the one that has
default attribute which equals true, will be associated with the LB rule.