### PR TITLE
Fixed a bug where a failed deployment puts system into an unrecoverab…

### DIFF
--- a/components/cookbooks/volume/metadata.rb
+++ b/components/cookbooks/volume/metadata.rb
@@ -109,6 +109,28 @@ attribute 'raid_options',
           ['RAID1','RAID 1']]}
   }
 
+ attribute 'control_skip_vol',
+  :description => 'Governs skip_vol attribute visibility in UI',
+  :default => 'false',
+  :format => {
+      :help => 'Azure only! Check if skip_vol checkbox should be editable in UI',
+      :category => '1.Global',
+      :form => { 'field' => 'checkbox' },
+      :filter   => { 'all' => { 'visible' => 'false' } },
+      :order => 5
+  }
+
+attribute 'skip_vol',
+  :description => 'Place on root',
+  :default => 'false',
+  :format => {
+      :help => 'Azure only! Skip volume processing and just mount the folder on root.',
+      :category => '1.Global',
+      :form => { 'field' => 'checkbox' },
+      :filter   => { 'all' => { 'visible' => 'control_skip_vol:eq:true' } },
+      :order => 6
+  }
+
 recipe "repair", "Repair Volume"
 
 recipe "log-grep",


### PR DESCRIPTION
…le state.

When volume recipe fails at attach step (for example due to a network blip),
it cannot gracefully recover after that failure. The reason is it's using
service files for each attached volume to store information about what device
the volume got attachced to. In case of failure that file gets no data and that
messes up all the following logic as it's heavily relied on the device id of
the attached volume.
To fix that I added extra logic to query provider data to determine the device
id.
Also I synced up the latest changes from main-1 circuit, to place ephemeral
volumes in azure onto root.