### PR TITLE
Updating the solr process monitor to trigger any unhealthy event if all cores are down in a node

### DIFF
--- a/components/cookbooks/solrcloud/templates/default/check_solr_process.rb.erb
+++ b/components/cookbooks/solrcloud/templates/default/check_solr_process.rb.erb
@@ -56,23 +56,26 @@ begin
     logger.info "Checking cores for ip=#{host_ip}, port=#{port_no}"
     total_cores, active_cores, recovering_cores, down_cores, recovery_failed_cores = check_solr_process_status_based_on_core_health(host_ip, port_no)
 
-    logger.info "\n\n total_cores => #{JSON.pretty_generate(total_cores)}"
-    logger.info "\n\n active_cores => #{JSON.pretty_generate(active_cores)}"
-    logger.info "\n\n recovering_cores => #{JSON.pretty_generate(recovering_cores)}"
+    cores_details = Hash.new
+
+    cores_details = {
+            "total_cores" => "#{total_cores}",
+            "active_cores" => "#{active_cores}",
+            "recovering_cores" => "#{recovering_cores}",
+            "down_cores" => "#{down_cores}",
+            "recovery_failed_cores" => "#{recovery_failed_cores}",
+    }
+
+    logger.info "\n\n cores_details => #{JSON.pretty_generate(cores_details)}"
 
     if(recovering_cores.length > 0) && (ping_cores(host_ip, port_no, recovering_cores, logger))
       logger.info "Following recovering cores exist in the current solr node and they are all pingable. solr is up"
-      logger.info "\n\n recovering cores => #{JSON.pretty_generate(recovering_cores)}"
       puts solr_up
     elsif(active_cores.length > 0) && (ping_cores(host_ip, port_no, active_cores, logger))
       logger.info "Following active cores exist in the current solr node and they are all pingable. solr is up"
-      logger.info "\n\n active cores => #{JSON.pretty_generate(active_cores)}"
       puts solr_up
     elsif(total_cores.length > 0)
       logger.info "Following cores exist in the current solr node which are neither active nor recovering. solr is down"
-      logger.info "\n\n total cores => #{JSON.pretty_generate(total_cores)}"
-      logger.info "\n\n down cores => #{JSON.pretty_generate(down_cores)}"
-      logger.info "\n\n recovery failed cores => #{JSON.pretty_generate(recovery_failed_cores)}"
       puts solr_down
     else
       logger.info "None of the conditions to make the solr process down is met. "

--- a/components/cookbooks/solrcloud/templates/default/check_solr_process.rb.erb
+++ b/components/cookbooks/solrcloud/templates/default/check_solr_process.rb.erb
@@ -13,11 +13,25 @@ logger = Logger.new('/tmp/check_solr_process.log', 10, 1024*1024)
 logger.info ""
 logger.info ""
 logger.info ""
-logger.info "-----------------------------------------------------------"
+logger.info ""
+logger.info ""
+logger.info "------------------------------------------------------------------------------------------------------------"
 logger.info "Beginning solr process check at #{DateTime.now}"
-logger.info "-----------------------------------------------------------"
+logger.info "------------------------------------------------------------------------------------------------------------"
 
 port_no = ARGV[0]
+
+# if  recovering_cores_count > 0 && all_ping_ok (recovering_cores)
+#   solr_up
+# elsif active_cores_count > 0 && all_ping_ok (active_cores)
+#   # all cores are active and pingable
+#   solr_up
+# elsif total_core_count > 0
+#   # no core is recovering or active but the node has some cores on it
+#   solr_down
+# else
+#   solr_up
+# end
 
 begin
 
@@ -40,54 +54,32 @@ begin
   else
 
     logger.info "Checking cores for ip=#{host_ip}, port=#{port_no}"
-    all_cores_on_this_node, down_cores, recovering_cores = check_solr_process_status_based_on_core_health(host_ip, port_no)
-    logger.info "all_cores_on_this_node = #{all_cores_on_this_node.join(', ')}"
-    logger.info "down_cores = #{down_cores.join(', ')}"
+    total_cores, active_cores, recovering_cores, down_cores, recovery_failed_cores = check_solr_process_status_based_on_core_health(host_ip, port_no)
 
-    # Get the active/ recovering cores alone from the available cores. => Remove just the down cores and apply ping on them
-    not_down_cores = all_cores_on_this_node - down_cores
-    logger.info "not_down_cores = #{not_down_cores.join(', ')}"
+    logger.info "\n\n total_cores => #{JSON.pretty_generate(total_cores)}"
+    logger.info "\n\n active_cores => #{JSON.pretty_generate(active_cores)}"
+    logger.info "\n\n recovering_cores => #{JSON.pretty_generate(recovering_cores)}"
 
-    if down_cores.length != 0
-      # TODO: Should we check if any other core is active on solr, then do not mark the process as down
-      if recovering_cores == 0
-        logger.info "Found down_cores without any recovering cores. declaring solr process down"
-        puts solr_down
-      else
-        logger.info "Below cores #{recovering_cores.join(', ')} are recovering on this node. So not marking the solrprocess as down"
-        # TODO: check if puts solr_up is needed
-        puts solr_up
-      end
+    if(recovering_cores.length > 0) && (ping_cores(host_ip, port_no, recovering_cores, logger))
+      logger.info "Following recovering cores exist in the current solr node and they are all pingable. solr is up"
+      logger.info "\n\n recovering cores => #{JSON.pretty_generate(recovering_cores)}"
+      puts solr_up
+    elsif(active_cores.length > 0) && (ping_cores(host_ip, port_no, active_cores, logger))
+      logger.info "Following active cores exist in the current solr node and they are all pingable. solr is up"
+      logger.info "\n\n active cores => #{JSON.pretty_generate(active_cores)}"
+      puts solr_up
+    elsif(total_cores.length > 0)
+      logger.info "Following cores exist in the current solr node which are neither active nor recovering. solr is down"
+      logger.info "\n\n total cores => #{JSON.pretty_generate(total_cores)}"
+      logger.info "\n\n down cores => #{JSON.pretty_generate(down_cores)}"
+      logger.info "\n\n recovery failed cores => #{JSON.pretty_generate(recovery_failed_cores)}"
+      puts solr_down
     else
-      if (!not_down_cores.empty? && not_down_cores.length != 0)
-
-        ping_ok = 0
-
-        not_down_cores.each do |core|
-
-          ping_url = "/solr/#{core}/admin/ping?qi=internal_admin&wt=json"
-	        ping_result = solr_rest_api(host_ip, port_no, ping_url)
-          ping_status =  ping_result["status"]
-          puts "Ping Status - #{ping_status}"
-          logger.info "Ping status for #{core} - #{ping_status}"
-          if (ping_status == "OK")
-            ping_ok += 1
-          end
-        end
-
-        if (not_down_cores.length == ping_ok)
-          logger.info "Solr is up, all cores ok"
-          puts solr_up
-        else
-          logger.info "Did not receive ping=OK for all the up cores, declaring solr process down"
-          puts solr_down
-        end
-      else
-        logger.info "not_down_cores #{} is empty"
-        # TODO: check if we have to make solr process down in this scenario
-        puts solr_up
-      end
+      logger.info "None of the conditions to make the solr process down is met. "
+      logger.info "No cores available on the current node. So solr process is up"
+      puts solr_up
     end
+
   end
   logger.close
 

--- a/components/cookbooks/solrcloud/templates/default/solr_util.rb.erb
+++ b/components/cookbooks/solrcloud/templates/default/solr_util.rb.erb
@@ -22,7 +22,7 @@ def parseShardListObject(shardList, collectionInfo, cores)
       replicas = collectionInfo["shards"][shard]["replicas"].keys
       replicas.each do |replica|
         replicaCore = collectionInfo["shards"][shard]["replicas"][replica]["core"]
-         if cores.include? replicaCore
+        if cores.include? replicaCore
           replicaState = collectionInfo["shards"][shard]["replicas"][replica]["state"]
           if replicaState == "active"
             active = active + 1
@@ -119,7 +119,7 @@ def checkSolrProcessIsRunning(solrPortNo)
   healthCheckResponse = solr_rest_api_get_auth("127.0.0.1", solrPortNo, healthCheckUrl)
 
   if(healthCheckResponse.code == '200')
-   isRunning = true
+    isRunning = true
   end
 
   return isRunning
@@ -127,9 +127,10 @@ end
 
 def check_solr_process_status_based_on_core_health(host_ip, solr_port_no)
 
-  local_cores = []
+  total_cores = []
   down_cores = []
   recovering_cores = []
+  recovery_failed_cores = []
   active_cores = []
 
   solrCollectionUrl = "/solr/admin/collections?"
@@ -138,58 +139,56 @@ def check_solr_process_status_based_on_core_health(host_ip, solr_port_no)
   clusterstatus_url = "#{solrCollectionUrl}action=CLUSTERSTATUS&wt=json"
   cluster_status = solr_rest_api(host_ip, solr_port_no, clusterstatus_url)
 
-  collections = cluster_status["cluster"]["collections"].keys
-
   # Get the json of collections from clusterstatus which includes shard and replica details
   cluster_status_collections = cluster_status["cluster"]["collections"]
 
-  # Iterate through the collections in the cluster status
-  collections.each do |collection|
-    unless cluster_status_collections[collection]["shards"].nil?
+  cluster_status_collections.each { |coll_name, coll_info|
+    unless coll_info["shards"].nil?
+      shards = coll_info["shards"]
+      shards.each { |shard_name, shard_info|
+        unless shard_info["replicas"].nil?
+          replicas = shard_info["replicas"]
+          replicas.each { |replica_name, replica_info|
+            core = replica_info["core"]
+            base_url = replica_info["base_url"]
 
-      # Get all the shard names
-      shards = cluster_status_collections[collection]["shards"].keys
-      shards_list = cluster_status_collections[collection]["shards"]
+            # Get the core information for the current node
+            if base_url.include? host_ip
+              total_cores.push(replica_info["core"])
 
-      shards.each do |shard|
-
-        unless shards_list[shard]["replicas"].nil?
-
-          # Get all the replicas irrespective if shard is active or not
-          replicas = shards_list[shard]["replicas"].keys
-          replicas_list = shards_list[shard]["replicas"]
-
-          replicas.each do |replica|
-
-            if replicas_list[replica]["base_url"].include? host_ip
-              local_cores.push(replicas_list[replica ]["core"])
-
-              if replicas_list[replica]["state"] == "down"
-                if !down_cores.include?( replicas_list[replica]["core"] )
-                  down_cores.push( replicas_list[replica]["core"] )
+              if replica_info["state"] == "down"
+                if !down_cores.include?( replica_info["core"] )
+                  down_cores.push(replica_info["core"])
                 end
               end
 
-              if replicas_list[replica]["state"] == "active"
-                if !active_cores.include?( replicas_list[replica]["core"] )
-                  active_cores.push( replicas_list[replica]["core"] )
+              if replica_info["state"] == "active"
+                if !active_cores.include?( replica_info["core"] )
+                  active_cores.push(replica_info["core"])
                 end
               end
 
-              if replicas_list[replica]["state"] == "recovering"
-                if !recovering_cores.include?( replicas_list[replica]["core"] )
-                  recovering_cores.push( replicas_list[replica]["core"] )
+              if replica_info["state"] == "recovering"
+                if !recovering_cores.include?( replica_info["core"] )
+                  recovering_cores.push(replica_info["core"])
                 end
               end
 
+              if replica_info["state"] == "recovery_failed"
+                if !recovery_failed_cores.include?( replica_info["core"] )
+                  recovery_failed_cores.push(replica_info["core"])
+                end
+              end
             end
-          end
+          }
         end
-      end
-    end
-  end
 
-  return local_cores, down_cores, recovering_cores
+      }
+    end
+
+  }
+
+  return total_cores, active_cores, recovering_cores, down_cores, recovery_failed_cores
 end
 
 def solr_rest_api(host, port, url)
@@ -246,6 +245,35 @@ def solr_rest_api_get_auth(host, port, uri)
 
   return resp
 
+end
+
+def ping_cores(host_ip, port_no, cores, logger)
+  if (!cores.empty? && cores.length != 0)
+
+    ping_ok = 0
+
+    cores.each do |core|
+
+      ping_url = "/solr/#{core}/admin/ping?qi=internal_admin&wt=json"
+      ping_result = solr_rest_api(host_ip, port_no, ping_url)
+      ping_status =  ping_result["status"]
+      logger.info "Ping #{core} - #{ping_status}"
+      if (ping_status == "OK")
+        ping_ok += 1
+      end
+    end
+
+    if (cores.length == ping_ok)
+      logger.info "Solr is up, all cores ok"
+      return true
+    else
+      logger.info "Did not receive ping=OK for all the up cores."
+      return false
+    end
+  else
+    logger.info "cores list #{cores} is empty"
+    return true
+  end
 end
 
 


### PR DESCRIPTION
Updating the solr process monitor to trigger any unhealthy event if all cores are down in a node

```
if  recovering_cores_count > 0 && all_ping_ok (recovering_cores)
    solr_up
elsif active_cores_count > 0 && all_ping_ok (active_cores)
    (all cores are active and pingable)
    solr_up
elsif total_core_count > 0
   (no core is recovering or active but the node has some cores on it)
   solr_down
else
  solr_up
end
