### PR TITLE
Add FairScheduler configs

### DIFF
--- a/components/cookbooks/hadoop-yarn-v1/templates/default/yarn-site.xml.erb
+++ b/components/cookbooks/hadoop-yarn-v1/templates/default/yarn-site.xml.erb
@@ -40,6 +40,20 @@
         <value><%= @primaryResourceManager %>:8050</value>
     </property>
 
+    <!-- FairScheduler configuration -->
+    <property>
+        <name>yarn.resourcemanager.scheduler.class</name>
+        <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler</value>
+    </property>
+    <property>
+        <name>yarn.scheduler.fair.preemption</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>yarn.scheduler.fair.assignmultiple</name>
+        <value>true</value>
+    </property>
+
     <!-- NodeManager configuration -->
 <% if spark_dist == "" %>
     <property>


### PR DESCRIPTION
By default Yarn is using capacity scheduler, and without configuration, any preceding job will take all the resources of the cluster and other jobs will just wait.

Better use fair scheduler as that one works better.